### PR TITLE
Correct enum types, strictFrom and char * for variable data at buffer end

### DIFF
--- a/compileDataView.js
+++ b/compileDataView.js
@@ -1,21 +1,21 @@
 /*
- * Copyright (c) 2021-2022  Moddable Tech, Inc.
- *
- *   This file is part of the Moddable SDK Tools.
- *
- *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
- *   (at your option) any later version.
- *
- *   The Moddable SDK Tools is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU General Public License for more details.
- *
- *   You should have received a copy of the GNU General Public License
- *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
- */
+* Copyright (c) 2021-2022  Moddable Tech, Inc.
+*
+*   This file is part of the Moddable SDK Tools.
+*
+*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   The Moddable SDK Tools is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 /*
 
@@ -40,7 +40,7 @@ const byteCounts = {
 	Float32: 4,
 	Float64: 8,
 	BigInt64: 8,
-	BigUint64: 8,
+	BigUint64: 8
 };
 
 const shiftCounts = {
@@ -53,42 +53,40 @@ const shiftCounts = {
 	Float32: 2,
 	Float64: 3,
 	BigInt64: 3,
-	BigUint64: 3,
+	BigUint64: 3
 };
 
 const TypeAliases = {
-	uint8_t: 'Uint8',
-	uint16_t: 'Uint16',
-	uint32_t: 'Uint32',
-	uint64_t: 'BigUint64',
-	int8_t: 'Int8',
-	int16_t: 'Int16',
-	int32_t: 'Int32',
-	int64_t: 'BigInt64',
-	float: 'Float32',
-	double: 'Float64',
-	boolean: 'Boolean',
-	bool: 'Boolean',
+	uint8_t:  "Uint8",
+	uint16_t:  "Uint16",
+	uint32_t:  "Uint32",
+	uint64_t:  "BigUint64",
+	int8_t:  "Int8",
+	int16_t:  "Int16",
+	int32_t:  "Int32",
+	int64_t:  "BigInt64",
+	float:  "Float32",
+	double:  "Float64",
+	boolean: "Boolean",
+	bool: "Boolean"
 };
 
 const TypeScriptTypeAliases = {
-	Uint8: 'number',
-	Uint16: 'number',
-	Uint32: 'number',
-	BigUint64: 'bigint',
-	Int8: 'number',
-	Int16: 'number',
-	Int32: 'number',
-	BigInt64: 'bigint',
-	Float32: 'number',
-	Float64: 'number',
-	Boolean: 'boolean',
-};
+	Uint8: "number",
+	Uint16: "number",
+	Uint32: "number",
+	BigUint64: "bigint",
+	Int8: "number",
+	Int16: "number",
+	Int32: "number",
+	BigInt64: "bigint",
+	Float32: "number",
+	Float64: "number",
+	Boolean: "boolean"
+}
 
-const EnumTypes = [];
-
-const isTypedef = Symbol('typedef');
-const anonymous = Symbol('anonymous');
+const isTypedef = Symbol("typedef");
+const anonymous = Symbol("anonymous");
 
 let className;
 let superClassName;
@@ -101,8 +99,8 @@ let jsonOutput;
 let fromOutput;
 let byteOffset;
 let littleEndian;
-let hostEndian;
-let useEndian; // = littleEndian ?? hostEndian
+let hostEndian
+let useEndian;	// = littleEndian ?? hostEndian
 let language;
 let platform;
 let doSet;
@@ -137,88 +135,95 @@ let outputSource;
 
 class Output extends Array {
 	add(line) {
-		if ('object' === typeof line) {
+		if ("object" === typeof line) {
 			line = line[language];
-			if (undefined === line) throw new Error(`no generated code for ${language}`);
+			if (undefined === line)
+				throw new Error(`no generated code for ${language}`);
 		}
 		if (line.length) this.push(line);
 	}
 	push(value, etc) {
-		if (etc) throw new Error('unexpected');
-		if (undefined === value) return;
+		if (etc) throw new Error("unexpected");
+		if (undefined === value)
+			return;
 		super.push(value);
 	}
 }
 
-const hex = '0123456789ABCDEF';
+const hex = "0123456789ABCDEF";
 function toHex(value, byteCount = 4) {
-	let result = '';
+	let result = "";
 	let nybbles = byteCount * 2;
 	while (value && nybbles--) {
 		result = hex[value & 15] + result;
-		value = (value & 0xfffffff0) >>> 4;
+		value = (value & 0xFFFFFFF0) >>> 4;
 	}
-	return '0x' + ('' === result ? '0' : result);
+	return "0x" + (("" === result) ? "0" : result);
 }
 
 function booleanSetting(value, name) {
-	if ('true' === value) return true;
+	if ("true" === value)
+		return true;
 
-	if ('false' === value) return false;
+	if ("false" === value)
+		return false;
 
 	throw new Error(`invalid ${name} "${value}" specified`);
 }
 
 function endField(byteCount) {
-	if (undefined !== union) union = Math.max(byteCount, union);
-	else byteOffset += byteCount;
+	if (undefined !== union)
+		union = Math.max(byteCount, union);
+	else
+		byteOffset += byteCount;
 }
 
 function validateName(name) {
 	//@@ naive
 	const c = name.charCodeAt(0);
-	if (48 <= c && c < 58) throw new Error(`invalid name "${name}"`);
-	if (name.includes(';') || name.includes('+') || name.includes('-') || name.includes('.') || name.includes('&'))
+	if ((48 <= c) && (c < 58))
+		throw new Error(`invalid name "${name}"`);		
+	if (name.includes(";") || name.includes("+")  || name.includes("-") || name.includes(".") || name.includes("&"))
 		throw new Error(`invalid name "${name}"`);
 
 	return name;
 }
 
 function splitSource(source) {
-	let parts = [],
-		part = '';
+	let parts = [], part = "";
 	let map = [];
 	let line = 1;
-	let directive = false,
-		lineStart = true;
+	let directive = false, lineStart = true;
 	let error;
 
-	splitLoop: for (let i = 0, length = source.length; i < length; i++) {
-		const c = source[i];
+splitLoop:
+	for (let i = 0, length = source.length; i < length; i++) {
+		const c = source[i]
 
-		if ('\n' === c) lineStart = true;
+		if ("\n" === c)
+			lineStart = true;
 
 		switch (c) {
-			case '*':
-				if ('/' === part) {
-					part = '';
+			case "*":
+				if ("/" === part) {
+					part = "";
 
-					const endComment = source.indexOf('*/', i);
+					const endComment = source.indexOf("*/", i);
 					if (endComment < 0) {
 						error = `unterminated comment, line ${line}`;
 						break splitLoop;
 					}
 					parts.push(source.slice(i - 1, endComment + 2));
 					map.push(line);
-					line += source.slice(i, endComment).split('\n').length - 1;
-					i = endComment + 1; // with ++ in for loop, this gives next character
+					line += source.slice(i, endComment).split("\n").length - 1;
+					i = endComment + 1;		// with ++ in for loop, this gives next character
 					continue splitLoop;
 				}
-			// fall through to handle "*" as separate part
+				// fall through to handle "*" as separate part
 
-			case '|':
-			case '&':
-			case '=':
+			case "|":
+			case "&":
+			case "=":
 				if (part) {
 					parts.push(part);
 					map.push(line);
@@ -226,41 +231,43 @@ function splitSource(source) {
 				if (c === source[i + 1]) {
 					parts.push(c + c);
 					i += 1;
-				} else parts.push(c);
+				}
+				else
+					parts.push(c);
 				map.push(line);
-				part = '';
+				part = "";
 				break;
 
-			case '{':
-			case '}':
-			case ':':
-			case ';':
-			case '[':
-			case ']':
-			case '(':
-			case ')':
-			case '+':
-			case '-':
-			case '^':
-			case '!':
-			case ',':
+			case "{":
+			case "}":
+			case ":":
+			case ";":
+			case "[":
+			case "]":
+			case "(":
+			case ")":
+			case "+":
+			case "-":
+			case "^":
+			case "!":
+			case ",":
 				if (part) {
 					parts.push(part);
 					map.push(line);
 				}
 				parts.push(c);
 				map.push(line);
-				part = '';
+				part = "";
 				break;
 
-			case '\n':
-			case '\t':
-			case ' ':
+			case "\n":
+			case "\t":
+			case " ":
 				if (part) {
 					parts.push(part);
 					map.push(line);
 				}
-				if ('\n' === c) {
+				if ("\n" === c) {
 					if (directive) {
 						directive = false;
 						parts.push(c);
@@ -269,22 +276,24 @@ function splitSource(source) {
 					line += 1;
 				}
 
-				part = '';
+				part = "";
 				break;
 
-			case '/':
-				if ('/' === part) {
-					part = '';
-					i = source.indexOf('\n', i);
-					if (i < 0) break splitLoop;
-					i -= 1; // so line ending is parsed
+			case "/":
+				if ("/" === part) {
+					part = "";
+					i = source.indexOf("\n", i);
+					if (i < 0)
+						break splitLoop;
+					i -= 1;		// so line ending is parsed
 					continue splitLoop;
 				}
 				part += c;
 				break;
 
-			case '#':
-				if (lineStart) directive = true;
+			case "#":
+				if (lineStart)
+					directive = true;
 				part += c;
 				break;
 
@@ -293,7 +302,8 @@ function splitSource(source) {
 				break;
 		}
 
-		if (' ' !== c && '\t' !== c && '\n' !== c) lineStart = false;
+		if ((" " !== c) && ("\t" !== c) && ("\n" !== c))
+			lineStart = false;
 	}
 
 	if (part) {
@@ -301,55 +311,49 @@ function splitSource(source) {
 		map.push(line);
 	}
 
-	return { parts, map, error };
+	return {parts, map, error};
 }
 
 function flushBitfields(bitsToAdd = 32) {
-	let total = 0,
-		type,
-		endian,
-		byteCount;
+	let total = 0, type, endian, byteCount;
 
-	for (let i = 0; i < bitfields.length; i++) total += bitfields[i].bitCount;
+	for (let i = 0; i < bitfields.length; i++)
+		total += bitfields[i].bitCount;
 
-	if (0 == total || total + bitsToAdd <= 32) return;
+	if ((0 == total) || ((total + bitsToAdd) <= 32))
+		return;
 
 	if (total <= 8) {
-		type = 'Uint8';
+		type = "Uint8";
 		byteCount = 1;
-		endian = '';
-	} else {
-		type = total <= 16 ? 'Uint16' : 'Uint32';
-		byteCount = total <= 16 ? 2 : 4;
-		endian = useEndian ? ', true' : ', false';
+		endian = "";
+	}
+	else {
+		type = (total <= 16) ? "Uint16" : "Uint32";
+		byteCount = (total <= 16) ? 2 : 4;
+		endian = useEndian ? ", true" : ", false";
 	}
 
 	let bitsOutput = 0;
 	while (bitfields.length) {
 		const bitfield = bitfields.shift();
-		const bitOffset = bitfieldsLSB ? bitsOutput : (byteCount << 3) - bitsOutput - bitfield.bitCount;
-		const mask = 2 ** bitfield.bitCount - 1;
-		const shiftLeft = bitOffset ? ' << ' + bitOffset : '';
-		const shiftRight = bitOffset ? ' >> ' + bitOffset : '';
+		const bitOffset = bitfieldsLSB ? bitsOutput : ((byteCount << 3) - bitsOutput - bitfield.bitCount);
+		const mask = (2 ** bitfield.bitCount) - 1;
+		const shiftLeft = bitOffset ? " << " + bitOffset : "";
+		const shiftRight = bitOffset ? " >> " + bitOffset : "";
 
 		if (doGet && !bitfield.name.startsWith(paddingPrefix)) {
-			if (bitfield.jsdocComment) output.push(bitfield.jsdocComment);
+			if (bitfield.jsdocComment)
+				output.push(bitfield.jsdocComment);
 
 			output.add({
 				javascript: `   get ${bitfield.name}() {`,
-				typescript: `   get ${bitfield.name}(): ${bitfield.boolean ? 'boolean' : 'number'} {`,
+				typescript: `   get ${bitfield.name}(): ${bitfield.boolean ? "boolean" : "number"} {`,
 			});
 			if (bitfield.boolean)
-				output.push(
-					`      return Boolean(this.get${type}(${byteOffset}${endian}) & ${toHex(
-						mask << bitOffset,
-						byteCount
-					)});`
-				);
+				output.push(`      return Boolean(this.get${type}(${byteOffset}${endian}) & ${toHex(mask << bitOffset, byteCount)});`);
 			else
-				output.push(
-					`      return (this.get${type}(${byteOffset}${endian})${shiftRight}) & ${toHex(mask, byteCount)};`
-				);
+				output.push(`      return (this.get${type}(${byteOffset}${endian})${shiftRight}) & ${toHex(mask, byteCount)};`);
 			output.push(`   }`);
 		}
 
@@ -358,37 +362,19 @@ function flushBitfields(bitsToAdd = 32) {
 
 			output.add({
 				javascript: `   set ${bitfield.name}(value) {`,
-				typescript: `   set ${bitfield.name}(value: ${bitfield.boolean ? 'boolean' : 'number'}) {`,
+				typescript: `   set ${bitfield.name}(value: ${bitfield.boolean ? "boolean" : "number"}) {`,
 			});
 			if (bitfield.boolean) {
 				output.push(`      const t = this.get${type}(${byteOffset}${endian});`);
-				output.push(
-					`      this.set${type}(${byteOffset}, value ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(
-						~(mask << bitOffset),
-						byteCount
-					)})${endian});`
-				);
-			} else if (1 === bitfield.bitCount) {
+				output.push(`      this.set${type}(${byteOffset}, value ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(~(mask << bitOffset), byteCount)})${endian});`);
+			}
+			else if (1 === bitfield.bitCount) {
 				output.push(`      const t = this.get${type}(${byteOffset}${endian});`);
-				output.push(
-					`      this.set${type}(${byteOffset}, (value & 1) ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(
-						~(mask << bitOffset),
-						byteCount
-					)})${endian});`
-				);
-			} else {
-				output.push(
-					`      const t = this.get${type}(${byteOffset}${endian}) & ${toHex(
-						~(mask << bitOffset),
-						byteCount
-					)};`
-				);
-				output.push(
-					`      this.set${type}(${byteOffset}, t | ((value & ${toHex(
-						mask,
-						byteCount
-					)})${shiftLeft})${endian});`
-				);
+				output.push(`      this.set${type}(${byteOffset}, (value & 1) ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(~(mask << bitOffset), byteCount)})${endian});`);
+			}
+			else {
+				output.push(`      const t = this.get${type}(${byteOffset}${endian}) & ${toHex(~(mask << bitOffset), byteCount)};`);
+				output.push(`      this.set${type}(${byteOffset}, t | ((value & ${toHex(mask, byteCount)})${shiftLeft})${endian});`);
 			}
 			output.push(`   }`);
 		}
@@ -403,110 +389,127 @@ function flushBitfields(bitsToAdd = 32) {
 
 function setPragma(setting, value) {
 	switch (setting) {
-		case 'extends':
-			extendsClass = value ? validateName(value) : 'DataView';
+		case "extends":
+			extendsClass = value ? validateName(value) : "DataView"
 			break;
 
-		case 'endian':
-			if ('little' === value) littleEndian = true;
-			else if ('big' === value) littleEndian = false;
-			else if ('host' === value) littleEndian = undefined;
-			else throw new Error(`invalid endian "${value}" specified`);
+		case "endian":
+			if ("little" === value)
+				littleEndian = true;
+			else if ("big" === value)
+				littleEndian = false;
+			else if ("host" === value)
+				littleEndian = undefined;
+			else
+				throw new Error(`invalid endian "${value}" specified`);
 
 			useEndian = littleEndian ?? hostEndian;
 			break;
 
-		case 'hostEndian':
-			if (output.length || final.length || className) throw new Error('too late to set hostEndian');
+		case "hostEndian":
+			if (output.length || final.length || className)
+				throw new Error("too late to set hostEndian");
 
-			if ('little' === value) hostEndian = true;
-			else if ('big' === value) hostEndian = false;
-			else if ('unknown' === value) hostEndian = undefined;
-			else throw new Error(`invalid hostEndian "${value}" specified`);
+			if ("little" === value)
+				hostEndian = true;
+			else if ("big" === value)
+				hostEndian = false;
+			else if ("unknown" === value)
+				hostEndian = undefined;
+			else
+				throw new Error(`invalid hostEndian "${value}" specified`);
 
 			useEndian = littleEndian ?? hostEndian;
 			break;
 
-		case 'pack':
-			if (')' === value) {
-				value = kDefaultPack;
+		case "pack":
+			if (")" === value) {
+				value =  kDefaultPack;
 				pos -= 1;
-			} else {
+			}
+			else {
 				value = parseInt(value);
-				if (0 === value) value = kDefaultPack;
-				if (![1, 2, 4, 8, 16].includes(value)) throw new Error(`invalid pack`);
+				if (0 === value)
+					value = kDefaultPack;
+				if (![1, 2, 4, 8, 16].includes(value))
+					throw new Error(`invalid pack`);
 			}
 			pack = value;
 			break;
 
-		case 'language':
-			if (output.length || final.length || className) throw new Error('too late to set language');
+		case "language":
+			if (output.length || final.length || className)
+				throw new Error("too late to set language");
 
 			const languageParts = value.split('/');
 			if (languageParts.length < 1 || languageParts.length > 2)
 				throw new Error(`invalid language "${value}" specified; missing <language>{/<platform>}`);
 
-			if (!['javascript', 'typescript'].includes(languageParts[0]))
+			if (!["javascript", "typescript"].includes(languageParts[0]))
 				throw new Error(`invalid language "${value}" specified; language "${languageParts[0]}" unknown`);
-			if (2 == languageParts.length && !['xs', 'node', 'web'].includes(languageParts[1]))
+			if (2 == languageParts.length && !["xs", "node", "web"].includes(languageParts[1]))
 				throw new Error(`invalid language "${value}" specified; platform "${languageParts[1]}" unknown`);
 
 			language = languageParts[0];
-			platform = languageParts[1] ?? 'xs';
+			platform = languageParts[1] ?? "xs";
 			break;
 
-		case 'set':
+		case "set":
 			doSet = booleanSetting(value, setting);
 			break;
 
-		case 'get':
+		case "get":
 			doGet = booleanSetting(value, setting);
 			break;
 
-		case 'export':
+		case "export":
 			doExport = booleanSetting(value, setting);
 			break;
 
-		case 'outputByteLength':
+		case "outputByteLength":
 			outputByteLength = booleanSetting(value, setting);
 			break;
 
-		case 'checkByteLength':
+		case "checkByteLength":
 			checkByteLength = booleanSetting(value, setting);
 			break;
 
-		case 'json':
+		case "json":
 			json = booleanSetting(value, setting);
 			break;
 
-		case 'bitfields':
-			if ('lsb' === value) bitfieldsLSB = true;
-			else if ('msb' === value) bitfieldsLSB = false;
-			else throw new Error(`invalid bitfields "${value}" specified`);
+		case "bitfields":
+			if ("lsb" === value)
+				bitfieldsLSB = true;
+			else if ("msb" === value)
+				bitfieldsLSB = false;
+			else
+				throw new Error(`invalid bitfields "${value}" specified`);
 			break;
 
-		case 'comments':
-			if (!['header', 'false', 'true'].includes(value)) throw new Error(`invalid comments "${value}" specified`);
+		case "comments":
+			if (!["header", "false", "true"].includes(value))
+				throw new Error(`invalid comments "${value}" specified`);
 			comments = value;
 			break;
 
-		case 'inject':
+		case "inject":
 			if (jsdocClassComment) {
 				final.push(jsdocClassComment);
-				jsdocClassComment = '';
+				jsdocClassComment = "";
 			}
 			final.push(`${className ? '   ' : ''}${value};`);
 			break;
 
-		case 'injectInterface':
+		case "injectInterface":
 			injectInterface.push(`   ${value};`);
 			break;
 
-		case 'import':
+		case "import":
 			imports.push(`import ${value};`);
 			break;
 
-		case 'outputSource':
+		case "outputSource":
 			outputSource = booleanSetting(value, setting);
 			break;
 
@@ -522,77 +525,82 @@ function compileDataView(input, pragmas = {}) {
 	className = undefined;
 	superClassName = undefined;
 	classUsesEndian = false;
-	output = new Output();
+	output = new Output;
 	properties = [];
 	classes = {};
 	bitfields = [];
-	jsonOutput = new Output();
-	fromOutput = new Output();
+	jsonOutput = new Output;
+	fromOutput = new Output;
 	byteOffset = 0;
 	littleEndian = undefined;
 	hostEndian = true;
-	useEndian = littleEndian ?? hostEndian;
-	language = 'javascript';
-	platform = 'xs';
+	useEndian = littleEndian ?? hostEndian
+	language = "javascript";
+	platform = "xs";
 	doSet = true;
 	doGet = true;
 	doExport = true;
 	pack = kDefaultPack;
-	extendsClass = 'DataView';
+	extendsClass = "DataView";
 	imports = [];
 	outputByteLength = false;
 	checkByteLength = true;
 	union = undefined;
 	enumState = undefined;
-	enums = new Set();
-	enumContext = '';
+	enums = new Set;
+	enumContext = "";
 	classAlign = 0;
 	anonymousUnion = false;
 	json = false;
 	bitfieldsLSB = true;
-	comments = 'header';
+	comments = "header";
 	jsdocComment = undefined;
 	jsdocClassComment = undefined;
-	header = '';
+	header = "";
 	usesText = false;
 	usesEndianProxy = false;
 	usesViewArray = false;
-	conditionals = [{ active: true, else: true }];
-	paddingPrefix = '__pad';
+	conditionals = [{active: true, else: true}];
+	paddingPrefix = "__pad";
 	injectInterface = [];
 	exports = [];
 	outputSource = true;
 
 	final = [];
 	const errors = [];
-	const lines = input.split('\n');
+	const lines = input.split("\n");
 
-	const { parts, map, error } = splitSource(input);
+	const {parts, map, error} = splitSource(input);
 	if (error) {
 		errors.push(`   ${error}`);
 		parts.length = 0;
 	}
 
-	for (const name in pragmas) setPragma(name, pragmas[name]);
+	for (const name in pragmas)
+		setPragma(name, pragmas[name]);
 
 	for (let pos = 0; pos < parts.length; ) {
 		const part = parts[pos++];
-		if (!part) throw new Error('unexpected state');
+		if (!part)
+			throw new Error("unexpected state");
 
 		try {
 			let bitCount, arrayCount;
 
 			if (!conditionals[conditionals.length - 1].active) {
-				if ('#if' !== part && '#else' !== part && '#endif' !== part) continue;
+				if (("#if" !== part) && ("#else" !== part) && ("#endif" !== part))
+					continue;
 			}
 
-			if ('}' == part) {
-				if (!className) throw new Error(`unexpected }`);
+			if ("}" == part) {
+				if (!className)
+					throw new Error(`unexpected }`);
 
 				flushBitfields();
 
 				if (undefined !== union) {
-					if (0 === union) throw new Error(`empty union`);
+					if (0 === union)
+						throw new Error(`empty union`);
 
 					const byteLength = union;
 					union = undefined;
@@ -601,11 +609,13 @@ function compileDataView(input, pragmas = {}) {
 					if (anonymousUnion) {
 						anonymousUnion = false;
 
-						if (';' !== parts[pos++]) throw new Error(`expected semicolon`);
+						if (";" !== parts[pos++])
+							throw new Error(`expected semicolon`);
 
 						continue;
 					}
-				} else if (undefined !== enumState) {
+				}
+				else if (undefined !== enumState) {
 					if (anonymous !== className) {
 						exports.push(className);
 
@@ -615,7 +625,8 @@ function compileDataView(input, pragmas = {}) {
 						});
 						for (let [name, { value, jsdocComment }] of enumState) {
 							output.push(jsdocComment);
-							if ('string' === typeof value) value = '"' + value + '"';
+							if ("string" === typeof value)
+								value = '"' + value + '"';
 							output.add({
 								javascript: `   ${name}: ${value},`,
 								typescript: `   ${name} = ${value},`,
@@ -633,12 +644,11 @@ function compileDataView(input, pragmas = {}) {
 						const enumBackingBytes = byteCounts[enumBackingType];
 
 						classes[className] = {
-							byteLength: enumBackingBytes,
+							byteLength:  enumBackingBytes,
 							align: Math.min(pack, enumBackingBytes),
-							alignLength: enumBackingBytes,
+							alignLength: enumBackingBytes 
 						};
 						TypeAliases[className] = enumBackingType;
-						EnumTypes.push(className);
 					}
 
 					enumState = undefined;
@@ -649,20 +659,23 @@ function compileDataView(input, pragmas = {}) {
 
 				if (isTypedef === className) {
 					className = validateName(parts[pos++]);
-					if (classes[className]) throw new Error(`duplicate class "${className}"`);
+					if (classes[className])
+						throw new Error(`duplicate class "${className}"`);
 				}
 
-				if (';' !== parts[pos++]) throw new Error(`expected semicolon`);
+				if (";" !== parts[pos++])
+					throw new Error(`expected semicolon`);
 
 				if (json && byteOffset) {
 					if (doGet) {
 						output.add({
 							javascript: `   toJSON() {`,
-							typescript: `   toJSON(): object {`,
+							typescript: `   toJSON(): object {`
 						});
 						output.push(`      return {`);
 						output = output.concat(jsonOutput);
-						if (superClassName) output.push(`         ...super.toJSON()`);
+						if (superClassName)
+							output.push(`         ...super.toJSON()`);
 						output.push(`      };`);
 						output.push(`   }`);
 					}
@@ -670,23 +683,20 @@ function compileDataView(input, pragmas = {}) {
 
 					if (doSet) {
 						let interfaceTypes = `I${className}`;
-						for (
-							let parentClass = superClassName;
-							parentClass;
-							parentClass = classes[parentClass]?.superClassName
-						)
+						for (let parentClass = superClassName; parentClass; parentClass = classes[parentClass]?.superClassName)
 							interfaceTypes += ` & I${parentClass}`;
 						output.add({
 							javascript: `   static from(obj) {`,
-							typescript: `   static from(obj: ${interfaceTypes}): ${className} {`,
+							typescript: `   static from(obj: ${interfaceTypes}): ${className} {`
 						});
 						if (superClassName)
 							output.add({
 								javascript: `      const result = super.from(obj);`,
-								typescript: `      const result = <${className}> super.from(obj);`,
+								typescript: `      const result = <${className}> super.from(obj);`
 							});
-						else output.push(`      const result = new this();`);
-						output = output.concat(fromOutput.map((e) => e.replace('##LATE_CAST##', className)));
+						else
+							output.push(`      const result = new this();`);
+						output = output.concat(fromOutput.map(e => e.replace("##LATE_CAST##", className)));
 						output.push(`      return result;`);
 						output.push(`   }`);
 					}
@@ -696,9 +706,9 @@ function compileDataView(input, pragmas = {}) {
 				output.push(`}`);
 				output.push(``);
 
-				const start = new Output();
-				if ('typescript' == language) {
-					exports.push('I' + className);
+				const start = new Output;
+				if ("typescript" == language) {
+					exports.push("I" + className);
 					start.push(jsdocClassComment);
 					if (injectInterface.length == 0)
 						start.push(`type I${className} = Omit<${className}, keyof DataView | "toJSON">;`);
@@ -715,31 +725,27 @@ function compileDataView(input, pragmas = {}) {
 				jsdocClassComment = undefined;
 
 				let superByteLength = 0;
-				for (
-					let parentClass = superClassName;
-					classes[parentClass];
-					parentClass = classes[parentClass].extendsClass
-				)
+				for (let parentClass = superClassName; classes[parentClass]; parentClass = classes[parentClass].extendsClass)  
 					superByteLength += classes[parentClass].byteLength;
 
-				if (outputByteLength) start.push(`   static byteLength = ${byteOffset}`);
-				if (classUsesEndian) start.push(`   #endian;`);
+				if (outputByteLength)
+					start.push(`   static byteLength = ${byteOffset}`);
+				if (classUsesEndian)
+					start.push(`   #endian;`);
 
-				if (outputByteLength || classUsesEndian) start.push(``);
+				if (outputByteLength || classUsesEndian)
+					start.push(``);
 
 				if (byteOffset > 0) {
 					start.add({
 						javascript: `   constructor(data, offset = 0, length = ${byteOffset}) {`,
-						typescript: `   constructor(data?: ArrayBufferLike, offset = 0, length = ${byteOffset}) {`,
+						typescript: `   constructor(data?: ArrayBufferLike, offset = 0, length = ${byteOffset}) {`
 					});
 
 					if (!superClassName)
-						start.push(
-							`      super(data ?? new ArrayBuffer(offset + length), offset${
-								checkByteLength ? ', length' : ''
-							})`
-						);
-					else start.push(`      super(data, offset, length);`);
+						start.push(`      super(data ?? new ArrayBuffer(offset + length), offset${checkByteLength ? ", length" : ""})`);
+					else
+						start.push(`      super(data, offset, length);`);
 
 					if (classUsesEndian) {
 						start.push(`      this.setUint8(0, 1);`);
@@ -756,7 +762,7 @@ function compileDataView(input, pragmas = {}) {
 					align: classAlign,
 					alignLength: Math.ceil(byteOffset / classAlign) * classAlign,
 					superClassName,
-					superByteLength,
+					superByteLength
 				};
 
 				output.length = 0;
@@ -769,10 +775,12 @@ function compileDataView(input, pragmas = {}) {
 				continue;
 			}
 
-			if (part === 'union' && '{' === parts[pos]) {
-				if (!className) throw new Error(`anonymous union must be in struct`);
+			if ((part === "union") && ("{" === parts[pos])) {
+				if (!className)
+					throw new Error(`anonymous union must be in struct`);
 
-				if (undefined !== union) throw new Error(`no nested unions`);
+				if (undefined !== union)
+					throw new Error(`no nested unions`);
 
 				union = 0;
 				anonymousUnion = true;
@@ -781,11 +789,13 @@ function compileDataView(input, pragmas = {}) {
 				continue;
 			}
 
-			if (part === 'union') {
-				if ('{' !== parts[pos + 1]) throw new Error(`open brace expected`);
+			if (part === "union") {
+				if ("{" !== parts[pos + 1])
+					throw new Error(`open brace expected`);
 
 				className = validateName(parts[pos]);
-				if (classes[className]) throw new Error(`duplicate class "${className}"`);
+				if (classes[className])
+					throw new Error(`duplicate class "${className}"`);
 				classAlign = 1;
 
 				union = 0;
@@ -795,98 +805,116 @@ function compileDataView(input, pragmas = {}) {
 				continue;
 			}
 
-			if (part === 'enum') {
-				if (className) throw new Error(`enum must be at root`);
+			if (part === "enum") {
+				if (className)
+					throw new Error(`enum must be at root`);
 
 				let backingType = 'int32_t';
 
-				if ('{' !== parts[pos]) {
+				if ("{" !== parts[pos]) {
 					className = validateName(parts[pos++]);
-					if (classes[className]) throw new Error(`duplicate name "${enumState.name}"`);
+					if (classes[className])
+						throw new Error(`duplicate name "${enumState.name}"`);
 
 					if (':' == parts[pos]) {
 						backingType = parts[pos + 1];
-						if (!TypeAliases[backingType]) throw new Error(`unknown enum type ${backingType}`);
+						if (!TypeAliases[backingType])
+							throw new Error(`unknown enum type ${backingType}`);
 						pos += 2;
 					}
-				} else className = anonymous;
+				}
+				else
+					className = anonymous;
 
-				enumState = new Map();
+				enumState = new Map;
 				enumState.value = -1;
 				enumState.backingType = backingType;
-				enumState.typeName = className === anonymous ? backingType : className;
 
-				if ('{' !== parts[pos++]) throw new Error(`open brace expected`);
+				if ("{" !== parts[pos++])
+					throw new Error(`open brace expected`);
 
 				continue;
 			}
 
-			if (
-				'typedef' === part &&
-				('struct' === parts[pos] || ('volatile' == parts[pos] && 'struct' === parts[pos + 1]))
-			) {
-				if (className) throw new Error(`cannot nest structure`);
+			if (("typedef" === part) && (("struct" === parts[pos]) || (("volatile" == parts[pos]) && ("struct" === parts[pos + 1])))) {
+				if (className)
+					throw new Error(`cannot nest structure`);
 
-				if ('volatile' == parts[pos]) pos += 1;
+				if ("volatile" == parts[pos])
+					pos += 1;
 
-				if ('{' !== parts[pos + 1]) throw new Error(`open brace expected`);
+				if ("{" !== parts[pos + 1])
+					throw new Error(`open brace expected`);
 
 				className = isTypedef;
 				classAlign = 1;
-				jsonOutput = new Output();
-				fromOutput = new Output();
+				jsonOutput = new Output;
+				fromOutput = new Output;
 
 				pos += 2;
 				continue;
 			}
 
-			if ('struct' === part) {
-				if (className) throw new Error(`cannot nest structure`);
+			if ("struct" === part) {
+				if (className)
+					throw new Error(`cannot nest structure`);
 
 				className = validateName(parts[pos]);
-				if (classes[className]) throw new Error(`duplicate class "${className}"`);
+				if (classes[className])
+					throw new Error(`duplicate class "${className}"`);
 
-				if (':' == parts[pos + 1]) {
+				if (":" == parts[pos + 1]) {
 					superClassName = parts[pos + 2];
-					if (!classes[superClassName]) throw new Error(`unknown super class "${superClassName}"`);
+					if (!classes[superClassName])
+						throw new Error(`unknown super class "${superClassName}"`)
 					byteOffset = classes[superClassName].byteLength;
 				}
 
-				if ('{' !== parts[pos + (superClassName ? 3 : 1)]) throw new Error(`open brace expected`);
+				if ("{" !== parts[pos + (superClassName ? 3 : 1)])
+					throw new Error(`open brace expected`);
 
 				classAlign = 1;
-				jsonOutput = new Output();
-				fromOutput = new Output();
+				jsonOutput = new Output;
+				fromOutput = new Output;
 
-				pos += superClassName ? 4 : 2;
+				pos += (superClassName ? 4 : 2);
 				continue;
 			}
 
-			if (part.startsWith('/*')) {
-				if ('header' === comments && 1 === pos) header = part;
-				else if ('true' === comments) {
+			if (part.startsWith("/*")) {
+				if (("header" === comments) && (1 === pos))
+					header = part;
+				else if ("true" === comments) {
 					if (part.startsWith('/**')) {
-						if (className) jsdocComment = '   ' + part;
-						else jsdocClassComment = '\n' + part;
-					} else {
-						if (className) output.push('   ' + part);
-						else final.push(part);
+						if (className)
+							jsdocComment = '   ' + part;
+						else
+							jsdocClassComment = '\n' + part;
+					}
+					else {
+						if (className)
+							output.push('   ' + part);
+						else
+							final.push(part);
 					}
 				}
 				continue;
 			}
 
-			if ('#pragma' === part) {
+			if ("#pragma" === part) {
 				const setting = parts[pos++];
-				if ('(' !== parts[pos++]) throw new Error(`open parenthesis expected`);
+				if ("(" !== parts[pos++])
+					throw new Error(`open parenthesis expected`);
 
 				let value = [];
 				let nest = 0;
 				while (true) {
 					const part = parts[pos++];
-					if ('\n' === part) throw new Error(`unbalanced parenthesis`);
-					if ('(' === part) nest++;
-					else if (')' === part) {
+					if ("\n" === part)
+						throw new Error(`unbalanced parenthesis`);
+					if ("(" === part)
+						nest++;
+					else if (")" === part) {
 						if (0 === nest) {
 							pos--;
 							break;
@@ -895,22 +923,26 @@ function compileDataView(input, pragmas = {}) {
 					}
 					value.push(part);
 				}
-				value = value.join(' ');
-
+				value = value.join(" ");
+				
 				setPragma(setting, value);
 
-				if (')' !== parts[pos++]) throw new Error(`close parenthesis expected`);
+				if (")" !== parts[pos++])
+					throw new Error(`close parenthesis expected`);
 
-				if ('\n' !== parts[pos++]) throw new Error(`end of line expected`);
+				if ("\n" !== parts[pos++])
+					throw new Error(`end of line expected`);
 
 				continue;
 			}
-			if ('#if' === part) {
-				const end = parts.indexOf('\n', pos);
-				if (-1 == end) throw new Error(`syntax error`);
-				if (!conditionals[conditionals.length - 1].active) conditionals.push({ active: false });
+			if ("#if" === part) {
+				const end = parts.indexOf("\n", pos);
+				if (-1 == end)
+					throw new Error(`syntax error`);
+				if (!conditionals[conditionals.length - 1].active)
+					conditionals.push({active: false});
 				else {
-					const expression = parts.slice(pos, end).join(' ');
+					const expression = parts.slice(pos, end).join(" ");
 					let f = new Function(`
 						const p = new Proxy({}, {
 							has(target, property) {
@@ -933,267 +965,269 @@ function compileDataView(input, pragmas = {}) {
 						`);
 					const active = f() ?? false;
 					const type = typeof active;
-					if ('boolean' !== type && 'number' !== type) throw new Error(`invalid value for ${expression}`);
-					conditionals.push({ active: !!active });
+					if (("boolean" !== type) && ("number" !== type))
+						throw new Error(`invalid value for ${expression}`);
+					conditionals.push({active: !!active});
 				}
 
 				pos = end + 1;
 				continue;
 			}
-			if ('#else' === part) {
-				if (conditionals.length < 2 || conditionals[conditionals.length - 1].else)
+			if ("#else" === part) {
+				if ((conditionals.length < 2) || conditionals[conditionals.length - 1].else)
 					throw new Error(`unmatched #else`);
 				if (conditionals[conditionals.length - 2].active) {
 					conditionals[conditionals.length - 1].active = !conditionals[conditionals.length - 1].active;
 					conditionals[conditionals.length - 1].else = true;
 				}
 
-				const end = parts.indexOf('\n', pos);
-				if (-1 !== end) pos = end + 1;
+				const end = parts.indexOf("\n", pos);
+				if (-1 !== end)
+					pos = end + 1;
 				continue;
 			}
-			if ('#endif' === part) {
-				if (conditionals.length < 2) throw new Error(`unmatched #endif`);
+			if ("#endif" === part) {
+				if (conditionals.length < 2)
+					throw new Error(`unmatched #endif`);
 				conditionals.pop();
 
-				const end = parts.indexOf('\n', pos);
-				if (-1 !== end) pos = end + 1;
+				const end = parts.indexOf("\n", pos);
+				if (-1 !== end)
+					pos = end + 1;
 				continue;
 			}
-			if ('#error' === part) {
-				const end = parts.indexOf('\n', pos);
-				throw new Error(parts.slice(pos, end < 0 ? parts.length : end).join(' '));
+			if ("#error" === part) {
+				const end = parts.indexOf("\n", pos);
+				throw new Error(parts.slice(pos, (end < 0) ? parts.length : end).join(" "))
 			}
 
-			if (part.startsWith('#')) throw new Error(`invalid preprocessor instruction`);
+			if (part.startsWith("#"))
+				throw new Error(`invalid preprocessor instruction`);
 
-			if (';' === part) continue;
+			if (";" === part)
+				continue;
 
-			if (!className) throw new Error(`unexpected`);
+			if (!className)
+				throw new Error(`unexpected`);
 
 			if (enumState) {
-				if (enumState.has(part)) throw new Error(`duplicate name ${part} in enum`);
+				if (enumState.has(part))
+					throw new Error(`duplicate name ${part} in enum`);
 
 				let value = ++enumState.value;
-				if ('=' === parts[pos]) {
+				if ("=" === parts[pos]) {
 					pos += 1;
-					const comma = parts.indexOf(',', pos);
-					const brace = parts.indexOf('}', pos);
-					if (-1 == comma && -1 == brace) throw new Error(`syntax error`);
-					const end = Math.min(comma < 0 ? 32767 : comma, brace < 0 ? 32767 : brace);
-					const expression = parts.slice(pos, end).join(' ');
-					let context = '(function () {\n' + enumContext;
+					const comma = parts.indexOf(",", pos);
+					const brace = parts.indexOf("}", pos);
+					if ((-1 == comma) && (-1 == brace))
+						throw new Error(`syntax error`);
+					const end = Math.min((comma < 0) ? 32767 : comma, (brace < 0) ? 32767 : brace);
+					const expression = parts.slice(pos, end).join(" ");
+					let context = "(function () {\n" + enumContext;
 					context += `return ${expression};\n`;
-					context += `})();`;
+					context += `})();`
 					enumState.value = value = eval(context);
 					const type = typeof value;
-					if ('number' != type && 'string' !== type && 'boolean' !== type)
+					if (("number" != type) && ("string" !== type) && ("boolean" !== type))
 						throw new Error(`invalid value for ${part}`);
 					pos = end;
 				}
 
-				if (',' === parts[pos]) pos += 1;
-				else if ('}' === parts[pos]);
-				else throw new Error(`syntax error`);
+				if ("," === parts[pos])
+					pos += 1;
+				else if ("}" === parts[pos])
+					;
+				else
+					throw new Error(`syntax error`);
 
-				if (enums.has(part)) throw new Error(`duplicate enum: ${part}`);
+				if (enums.has(part))
+					throw new Error(`duplicate enum: ${part}`);
 				enums.add(part);
 
 				enumState.set(part, { value, jsdocComment });
 				jsdocComment = undefined;
 
-				if ('string' === typeof value) value = '"' + value + '"';
+				if ("string" === typeof value)
+					value = '"' + value + '"';
 				enumContext += `const ${part} = ${value};\n`;
 
 				continue;
 			}
 
+
 			let type = part;
 			let name = validateName(parts[pos++]);
 			const isPadding = name.startsWith(paddingPrefix);
 
-			if (':' === parts[pos]) {
+			if (":" === parts[pos]) {
 				pos++;
 				bitCount = parseInt(parts[pos++]);
-				if (bitCount <= 0 || bitCount > 32 || isNaN(bitCount)) throw new Error(`invalid bit count`);
-			} else {
-				if ('[' == parts[pos]) {
-					const bracket = parts.indexOf(']', pos + 1);
-					if (bracket < 0) throw new Error(`right brace expected`);
+				if ((bitCount <= 0) || (bitCount > 32) || isNaN(bitCount))
+					throw new Error(`invalid bit count`);
+			}
+			else {
+				if ("[" == parts[pos]) {
+					const bracket = parts.indexOf("]", pos + 1);
+					if (bracket < 0)
+						throw new Error(`right brace expected`);
 
-					const expression = parts.slice(pos + 1, bracket).join(' ');
-					let context = '(function () {\n' + enumContext;
+					const expression = parts.slice(pos + 1, bracket).join(" ");
+					let context = "(function () {\n" + enumContext;
 					context += `return ${expression};\n`;
-					context += `})();`;
+					context += `})();`
 
 					arrayCount = eval(context);
 					pos = bracket + 1;
 
 					arrayCount = Math.round(arrayCount);
-					if (arrayCount <= 0 || isNaN(arrayCount) || Infinity === arrayCount)
+					if ((arrayCount <= 0) || isNaN(arrayCount) || (Infinity === arrayCount))
 						throw new Error(`invalid array count`);
 				}
 			}
 
-			if (properties.includes(name)) throw new Error(`duplicate name "${name}"`);
+			if (properties.includes(name))
+				throw new Error(`duplicate name "${name}"`);
 			properties.push(name);
 
-			if (';' !== parts[pos++]) throw new Error(`expected semicolon`);
-			let typescriptType = EnumTypes[EnumTypes.indexOf(type)];
-			if (TypeAliases[type]) type = TypeAliases[type];
+			if (";" !== parts[pos++])
+				throw new Error(`expected semicolon`);
+
+			if (TypeAliases[type])
+				type = TypeAliases[type];
 
 			if (bitCount) {
-				if ('Uint8' === type || 'Uint16' === type || 'Uint32' === type) {
+				if (("Uint8" === type) || ("Uint16" === type) || ("Uint32" === type)) {
 					const byteCount = byteCounts[type];
-					if (byteCount * 8 < bitCount) throw new Error(`${type} too small for bitfield`);
-					type = 'Uint';
+					if ((byteCount * 8) < bitCount)
+						throw new Error(`${type} too small for bitfield`);
+					type = "Uint";
 				}
 			}
 
 			switch (type) {
-				case 'Float32':
-				case 'Float64':
-				case 'Int8':
-				case 'Int16':
-				case 'Int32':
-				case 'Uint8':
-				case 'Uint16':
-				case 'Uint32':
-				case 'BigInt64':
-				case 'BigUint64':
-					{
-						flushBitfields();
-						if (undefined !== bitCount) throw new Error(`cannot use bitfield with "${type}"`);
-
-						const byteCount = byteCounts[type];
-
-						const align = Math.min(pack, byteCount);
-						if (byteOffset % align) endField(align - (byteOffset % align));
-
-						if (classAlign < align) classAlign = align;
-
-						if (doGet && !isPadding) {
-							output.push(jsdocComment);
-							output.add({
-								javascript: `   get ${name}() {`,
-								typescript: `   get ${name}(): ${
-									undefined === arrayCount ? typescriptType ?? TypeScriptTypeAliases[type] : `${type}Array`
-								} {`,
-							});
-							if (undefined === arrayCount) {
-								if (1 === byteCount) output.push(`      return this.get${type}(${byteOffset});`);
-								else {
-									if (undefined !== useEndian)
-										output.push(`      return this.get${type}(${byteOffset}, ${useEndian});`);
-									else {
-										output.push(`      return this.get${type}(${byteOffset}, this.#endian);`);
-										classUsesEndian = true;
-									}
-								}
-							} else {
-								if (1 === byteCount || hostEndian === useEndian)
-									output.push(
-										`      return new ${type}Array(this.buffer, this.byteOffset${
-											byteOffset ? ' + ' + byteOffset : ''
-										}, ${arrayCount});`
-									);
-								else {
-									output.push(
-										`      return new EndianArray(${useEndian}, ${
-											shiftCounts[type]
-										}, DataView.prototype.get${type}, DataView.prototype.set${type}, this.buffer, this.byteOffset${
-											byteOffset ? ' + ' + byteOffset : ''
-										}, ${arrayCount});`
-									);
-									usesEndianProxy = true;
-								}
-							}
-							output.push(`   }`);
-						}
-
-						if (doSet && !isPadding) {
-							output.push(jsdocComment);
-
-							output.add({
-								javascript: `   set ${name}(value) {`,
-								typescript: `   set ${name}(value: ${
-									undefined === arrayCount
-										? typescriptType ?? TypeScriptTypeAliases[type]
-										: `ArrayLike<${TypeScriptTypeAliases[type]}>`
-								}) {`,
-							});
-							output.push();
-							if (undefined === arrayCount) {
-								if (1 === byteCount) output.push(`      this.set${type}(${byteOffset}, value);`);
-								else {
-									if (undefined !== useEndian)
-										output.push(`      this.set${type}(${byteOffset}, value, ${useEndian});`);
-									else {
-										output.push(`      this.set${type}(${byteOffset}, value, this.#endian);`);
-										classUsesEndian = true;
-									}
-								}
-							} else {
-								if (byteCount == 1 || undefined !== useEndian) {
-									output.push(
-										`      for (let i = 0, j = this.byteOffset${
-											byteOffset ? ' + ' + byteOffset : ''
-										}; i < ${arrayCount}; i++, j += ${byteCount})`
-									);
-									if (1 === byteCount) output.push(`         this.set${type}(j, value[i]);`);
-									else output.push(`         this.set${type}(j, value[i], ${useEndian});`);
-								} else
-									output.push(
-										`      (new ${type}Array(this.buffer, this.byteOffset${
-											byteOffset ? ' + ' + byteOffset : ''
-										}, ${arrayCount})).set(value);`
-									);
-							}
-
-							output.push(`   }`);
-						}
-
-						endField((arrayCount ?? 1) * byteCount);
-
-						if (!isPadding) {
-							if (undefined === arrayCount) jsonOutput.push(`         ${name}: this.${name},`);
-							else jsonOutput.push(`         ${name}: Array.from(this.${name}),`);
-
-							fromOutput.add({
-								javascript: `      if ("${name}" in obj) result.${name} = obj.${name};`,
-								typescript: `      if ("${name}" in obj) result.${name} = (<##LATE_CAST##> obj).${name};`,
-							});
-						}
-					}
-					break;
-
-				case 'char':
+				case "Float32":
+				case "Float64":
+				case "Int8":
+				case "Int16":
+				case "Int32":
+				case "Uint8":
+				case "Uint16":
+				case "Uint32":
+				case "BigInt64":
+				case "BigUint64": {
 					flushBitfields();
+					if (undefined !== bitCount)
+						throw new Error(`cannot use bitfield with "${type}"`);
 
-					if (undefined !== bitCount) throw new Error(`char cannot use bitfield`);
+					const byteCount = byteCounts[type];
+
+					const align = Math.min(pack, byteCount);
+					if (byteOffset % align)
+						endField(align - (byteOffset % align));
+
+					if (classAlign < align)
+						classAlign = align;
 
 					if (doGet && !isPadding) {
-						+output.push(jsdocComment);
+						output.push(jsdocComment);
+
+						output.add({
+							javascript: `   get ${name}() {`,
+							typescript: `   get ${name}(): ${(undefined === arrayCount) ? TypeScriptTypeAliases[type] : `${type}Array`} {`
+						});
+						if (undefined === arrayCount) {
+							if (1 === byteCount)
+								output.push(`      return this.get${type}(${byteOffset});`);
+							else {
+								if (undefined !== useEndian)
+									output.push(`      return this.get${type}(${byteOffset}, ${useEndian});`);
+								else {
+									output.push(`      return this.get${type}(${byteOffset}, this.#endian);`);
+									classUsesEndian = true;
+								}
+							}
+						}
+						else {
+							if ((1 === byteCount) || (hostEndian === useEndian))
+								output.push(`      return new ${type}Array(this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount});`);
+							else {
+								output.push(`      return new EndianArray(${useEndian}, ${shiftCounts[type]}, DataView.prototype.get${type}, DataView.prototype.set${type}, this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount});`);
+								usesEndianProxy = true;
+							}
+						}
+						output.push(`   }`);
+					}
+
+					if (doSet && !isPadding) {
+						output.push(jsdocComment);
+
+						output.add({
+							javascript: `   set ${name}(value) {`,
+							typescript: `   set ${name}(value: ${(undefined === arrayCount) ? TypeScriptTypeAliases[type] : `ArrayLike<${TypeScriptTypeAliases[type]}>`}) {`,
+						});
+						output.push();
+						if (undefined === arrayCount) {
+							if (1 === byteCount)
+								output.push(`      this.set${type}(${byteOffset}, value);`);
+							else {
+								if (undefined !== useEndian)
+									output.push(`      this.set${type}(${byteOffset}, value, ${useEndian});`);
+								else {
+									output.push(`      this.set${type}(${byteOffset}, value, this.#endian);`);
+									classUsesEndian = true;
+								}
+							}
+						}
+						else {
+							if ((byteCount == 1) || (undefined !== useEndian)) {
+								output.push(`      for (let i = 0, j = this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}; i < ${arrayCount}; i++, j += ${byteCount})`);
+								if (1 === byteCount)
+									output.push(`         this.set${type}(j, value[i]);`);
+								else
+									output.push(`         this.set${type}(j, value[i], ${useEndian});`);
+							}
+							else
+								output.push(`      (new ${type}Array(this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount})).set(value);`);
+						}
+
+						output.push(`   }`);
+					}
+
+					endField((arrayCount ?? 1) * byteCount);
+
+					if (!isPadding) {
+						if (undefined === arrayCount)
+							jsonOutput.push(`         ${name}: this.${name},`);
+						else
+							jsonOutput.push(`         ${name}: Array.from(this.${name}),`);
+
+						fromOutput.add({
+							javascript: `      if ("${name}" in obj) result.${name} = obj.${name};`,
+							typescript: `      if ("${name}" in obj) result.${name} = (<##LATE_CAST##> obj).${name};`
+						});
+					}
+					} break;
+
+				case "char":
+					flushBitfields();
+
+					if (undefined !== bitCount)
+						throw new Error(`char cannot use bitfield`);
+
+					if (doGet && !isPadding) {
++						output.push(jsdocComment);
 
 						output.add({
 							javascript: `   get ${name}() {`,
 							typescript: `   get ${name}(): string {`,
 						});
-						if (undefined === arrayCount || 1 === arrayCount)
+						if ((undefined === arrayCount) || (1 === arrayCount))
 							output.push(`      return String.fromCharCode(this.getUint8(${byteOffset}));`);
 						else {
-							if ('xs' === platform)
-								output.push(
-									`      return String.fromArrayBuffer(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${
-										byteOffset + arrayCount
-									}));`
-								);
+							if ("xs" === platform)
+								output.push(`      return String.fromArrayBuffer(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${byteOffset + arrayCount}));`);
 							else
-								output.push(
-									`      return new TextDecoder().decode(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${
-										byteOffset + arrayCount
-									}));`
-								);
+								output.push(`      return new TextDecoder().decode(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${byteOffset + arrayCount}));`);
 						}
 						output.push(`   }`);
 					}
@@ -1206,12 +1240,13 @@ function compileDataView(input, pragmas = {}) {
 							typescript: `   set ${name}(value: string) {`,
 						});
 						output.push();
-						if (undefined === arrayCount || 1 === arrayCount)
+						if ((undefined === arrayCount) || (1 === arrayCount))
 							output.push(`      this.setUint8(${byteOffset}, value.charCodeAt(0));`);
 						else {
-							if ('xs' === platform)
+							if ("xs" === platform)
 								output.push(`      const j = new Uint8Array(ArrayBuffer.fromString(value));`);
-							else output.push(`      const j = new TextEncoder().encode(value);`);
+							else
+								output.push(`      const j = new TextEncoder().encode(value);`);
 							output.push(`      const byteLength = j.byteLength;`);
 							output.push(`      if (byteLength > ${arrayCount})`);
 							output.push(`         throw new Error("too long");`);
@@ -1233,19 +1268,20 @@ function compileDataView(input, pragmas = {}) {
 							typescript: `      if ("${name}" in obj) result.${name} = (<##LATE_CAST##> obj).${name};`,
 						});
 					}
-
+					
 					usesText = true;
 					break;
 
-				case 'Uint':
-					if (undefined === bitCount) throw new Error(`number of bits in bitfield missing`);
+				case "Uint":
+					if (undefined === bitCount)
+						throw new Error(`number of bits in bitfield missing`);
 
 					flushBitfields(bitCount);
 
 					bitfields.push({
 						name,
 						bitCount,
-						jsdocComment,
+						jsdocComment
 					});
 
 					if (!isPadding) {
@@ -1258,18 +1294,20 @@ function compileDataView(input, pragmas = {}) {
 					}
 					break;
 
-				case 'Boolean':
+				case "Boolean":
 					flushBitfields(1);
 
-					if (undefined !== arrayCount) throw new Error(`Boolean cannot have array`);
+					if (undefined !== arrayCount)
+						throw new Error(`Boolean cannot have array`);
 
-					if (undefined !== bitCount) throw new Error(`cannot use bitfield with "${type}"`);
+					if (undefined !== bitCount)
+						throw new Error(`cannot use bitfield with "${type}"`);
 
 					bitfields.push({
 						name,
 						bitCount: 1,
 						boolean: true,
-						jsdocComment,
+						jsdocComment
 					});
 
 					if (!isPadding) {
@@ -1282,160 +1320,163 @@ function compileDataView(input, pragmas = {}) {
 					}
 					break;
 
-				default:
-					{
-						if (!classes[type]) throw new Error(`unknown type "${type}"`);
+				default: {
+					if (!classes[type])
+						throw new Error(`unknown type "${type}"`);
 
-						flushBitfields();
+					flushBitfields();
 
-						if (undefined !== bitCount) throw new Error(`cannot use bitfield with "${type}"`);
+					if (undefined !== bitCount)
+						throw new Error(`cannot use bitfield with "${type}"`);
 
-						const align = Math.min(pack, classes[type].align);
-						if (byteOffset % align) endField(align - (byteOffset % align));
+					const align = Math.min(pack, classes[type].align);
+					if (byteOffset % align)
+						endField(align - (byteOffset % align));
 
-						if (doGet && !isPadding) {
-							output.push(jsdocComment);
+					if (doGet && !isPadding) {
+						output.push(jsdocComment);
 
-							if (undefined === arrayCount) {
-								output.add({
-									javascript: `   get ${name}() {`,
-									typescript: `   get ${name}(): ${type} {`,
-								});
-
-								output.push(
-									`      return new ${type}(this.buffer, this.byteOffset${
-										byteOffset ? ' + ' + byteOffset : ''
-									});`
-								);
-								output.push(`   }`);
-							} else {
-								output.add({
-									javascript: `   get ${name}() {`,
-									typescript: `   get ${name}(): ArrayLike<${type}> {`,
-								});
-
-								output.push(
-									`      return new ViewArray(${type}, this.buffer, this.byteOffset${
-										byteOffset ? ' + ' + byteOffset : ''
-									}, ${arrayCount}, ${classes[type].alignLength});`
-								);
-								output.push(`   }`);
-
-								usesViewArray = true;
-							}
-						}
-
-						if (doSet && !isPadding) {
-							output.push(jsdocComment);
-
-							if (undefined === arrayCount) {
-								output.add({
-									javascript: `   set ${name}(value) {`,
-									typescript: `   set ${name}(value: ${type}) {`,
-								});
-								output.push(`      for (let i = 0; i < ${classes[type].byteLength}; i++)`);
-								output.push(`         this.setUint8(i + ${byteOffset}, value.getUint8(i));`);
-								output.push(`   }`);
-							} else {
-								output.add({
-									javascript: `   set ${name}(value) {`,
-									typescript: `   set ${name}(value: ArrayLike<${type}>) {`,
-								});
-								output.push(
-									`      for (let i = 0, offset = 0; i < ${arrayCount}; i++, offset += ${classes[type].alignLength}) {`
-								);
-								output.push(
-									`         for (let j = 0, v = value[i]; j < ${classes[type].byteLength}; j++) {`
-								);
-								output.push(`            this.setUint8(j + offset + ${byteOffset}, v.getUint8(j));`);
-								output.push(`         }`);
-								output.push(`      }`);
-								output.push(`   }`);
-							}
-						}
-
-						if (undefined === arrayCount) endField(classes[type].byteLength);
-						else endField(arrayCount * classes[type].alignLength);
-
-						if (!isPadding) {
-							jsonOutput.push(`         ${name}: this.${name}.toJSON(),`);
-
-							fromOutput.add({
-								javascript: `      if ("${name}" in obj) result.${name} = ${type}.from(obj.${name});`,
-								typescript: `      if ("${name}" in obj) result.${name} = ${type}.from((<##LATE_CAST##> obj).${name});`,
+						if (undefined === arrayCount) {
+							output.add({
+								javascript: `   get ${name}() {`,
+								typescript: `   get ${name}(): ${type} {`,
 							});
+								
+							output.push(`      return new ${type}(this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""});`);
+							output.push(`   }`);
+						}
+						else {
+							output.add({
+								javascript: `   get ${name}() {`,
+								typescript: `   get ${name}(): ArrayLike<${type}> {`,
+							});
+
+							output.push(`      return new ViewArray(${type}, this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount}, ${classes[type].alignLength});`);
+							output.push(`   }`);
+
+							usesViewArray = true;
 						}
 					}
-					break;
+
+					if (doSet && !isPadding) {
+						output.push(jsdocComment);
+
+						if (undefined === arrayCount) {
+							output.add({
+								javascript: `   set ${name}(value) {`,
+								typescript: `   set ${name}(value: ${type}) {`,
+							});
+							output.push(`      for (let i = 0; i < ${classes[type].byteLength}; i++)`);
+							output.push(`         this.setUint8(i + ${byteOffset}, value.getUint8(i));`);
+							output.push(`   }`);
+						}
+						else {
+							output.add({
+								javascript: `   set ${name}(value) {`,
+								typescript: `   set ${name}(value: ArrayLike<${type}>) {`,
+							});
+							output.push(`      for (let i = 0, offset = 0; i < ${arrayCount}; i++, offset += ${classes[type].alignLength}) {`) ;
+							output.push(`         for (let j = 0, v = value[i]; j < ${classes[type].byteLength}; j++) {`);
+							output.push(`            this.setUint8(j + offset + ${byteOffset}, v.getUint8(j));`);
+							output.push(`         }`);
+							output.push(`      }`);
+							output.push(`   }`);
+						}
+					}
+
+					if (undefined === arrayCount)
+						endField(classes[type].byteLength);
+					else
+						endField(arrayCount * classes[type].alignLength);
+
+
+					if (!isPadding) {
+						jsonOutput.push(`         ${name}: this.${name}.toJSON(),`);
+
+						fromOutput.add({
+							javascript: `      if ("${name}" in obj) result.${name} = ${type}.from(obj.${name});`,
+							typescript: `      if ("${name}" in obj) result.${name} = ${type}.from((<##LATE_CAST##> obj).${name});`,
+						});
+					}
+					} break;
 			}
 			jsdocComment = undefined;
-		} catch (e) {
+
+		}
+		catch (e) {
 			errors.push(`   ${e}, line ${map[pos]}: ${lines[map[pos] - 1]}`);
 		}
 	}
 
-	if (conditionals.length > 1) errors.push(`   missing #endif`);
+	if (conditionals.length > 1)
+		errors.push(`   missing #endif`);
 
-	if (className) errors.push(`   incomplete struct at end of file`);
+	if (className)
+		errors.push(`   incomplete struct at end of file`);
 
-	if (usesText && 'node' === platform) imports.push('import {TextEncoder, TextDecoder} from "util";');
+	if (usesText && ("node" === platform))
+		imports.push('import {TextEncoder, TextDecoder} from "util";');
 
-	if (imports.length) final.unshift(...imports, '');
+	if (imports.length)
+		final.unshift(...imports, "");
 
-	if (header) final.unshift(header, '');
+	if (header)
+		final.unshift(header, "");
 
-	if (usesEndianProxy) final.push(EndianProxy);
+	if (usesEndianProxy)
+		final.push(EndianProxy);
 
-	if (usesViewArray) final.push(ViewArray);
+	if (usesViewArray)
+		final.push(ViewArray);
 
 	if (exports.length && doExport) {
-		final.push('');
-		let exportLine = 'export { ';
+		final.push("");
+		let exportLine = "export { ";
 		if (exports.length > 3) {
 			final.push(exportLine);
-			exportLine = '';
+			exportLine = "";
 		}
 		for (let i = 0; i < exports.length; ++i) {
 			if (exportLine.length > 80) {
-				final.push('   ' + exportLine);
-				exportLine = '';
+				final.push("   " + exportLine);
+				exportLine = "";
 			}
-			exportLine = exportLine + exports[i] + (i < exports.length - 1 ? ', ' : '');
+			exportLine = exportLine + exports[i] + ((i < (exports.length - 1)) ? ', ' : '');
 		}
-		if (exportLine != '') {
-			if (exports.length <= 3) final.push(exportLine + ' };');
+		if (exportLine != "") {
+			if (exports.length <= 3)
+				final.push(exportLine + " };");
 			else {
-				final.push('   ' + exportLine);
-				final.push('};');
+				final.push("   " + exportLine);
+				final.push("};");
 			}
 		}
 	}
 
 	if (outputSource) {
-		final.push('');
-		final.push('/*');
-		final.push(
-			`\tView classes generated by https://phoddie.github.io/compileDataView on ${new Date()} from the following description:`
-		);
-		final.push('*/');
+		final.push("");
+		final.push("/*");
+		final.push(`\tView classes generated by https://phoddie.github.io/compileDataView on ${new Date} from the following description:`);
+		final.push("*/");
 		final.push(input.replace(/^|\n/g, '\n// '));
 	}
 
 	if (errors.length) {
-		errors.unshift('/*');
-		errors.push('*/');
-		errors.push('');
+		errors.unshift("/*")
+		errors.push("*/")
+		errors.push("")
 	}
 
 	return {
-		script: final.join('\n'),
-		errors: errors.join('\n'),
-		language: 'typescript' === language ? 'ts' : 'js',
-		platform,
-	};
+		script: final.join("\n"),
+		errors: errors.join("\n"),
+		language: ("typescript" === language) ? 'ts' : 'js',
+		platform
+	}
 }
 
-const EndianProxy = `const Properties = Object.freeze({
+const EndianProxy =
+`const Properties = Object.freeze({
 	concat: Array.prototype.concat,
 	copyWithin: Array.prototype.copyWithin,
 	every: Array.prototype.every,
@@ -1517,7 +1558,8 @@ class EndianArray {
 }
 `;
 
-const ViewArray = `class ViewArray {
+const ViewArray =
+`class ViewArray {
 	constructor(View, buffer, byteOffset, count, size) {
 		if ((count * size) > (buffer.byteLength - byteOffset))
 			throw new RangeError;

--- a/compileDataView.js
+++ b/compileDataView.js
@@ -113,6 +113,7 @@ let extendsClass;
 let imports;
 let outputByteLength;
 let checkByteLength;
+let useSharedArrayBuffer;
 let union;
 let enumState;
 let enums;
@@ -478,6 +479,10 @@ function setPragma(setting, value) {
 			checkByteLength = booleanSetting(value, setting);
 			break;
 
+		case "useSharedArrayBuffer":
+			useSharedArrayBuffer = booleanSetting(value, setting);
+			break;
+
 		case "json":
 			json = booleanSetting(value, setting);
 			break;
@@ -553,6 +558,7 @@ function compileDataView(input, pragmas = {}) {
 	imports = [];
 	outputByteLength = false;
 	checkByteLength = true;
+	useSharedArrayBuffer = false;
 	union = undefined;
 	enumState = undefined;
 	enums = new Set;
@@ -645,6 +651,9 @@ function compileDataView(input, pragmas = {}) {
 						output.add({
 							javascript: `});`,
 							typescript: `}`,
+						});
+						output.add({
+							typescript: `(<unknown> ${className}) = Object.freeze(${className});`,
 						});
 						output.push(``);
 
@@ -755,7 +764,7 @@ function compileDataView(input, pragmas = {}) {
 					});
 
 					if (!superClassName)
-						start.push(`      super(data ?? new ArrayBuffer(offset + (length ?? ${byteOffset})), offset${checkByteLength ? ", length ?? (data ? data.byteLength - offset : " + byteOffset + "))" : ""}`);
+						start.push(`      super(data ?? new ${useSharedArrayBuffer ? 'SharedArrayBuffer' : 'ArrayBuffer'}(offset + (length ?? ${byteOffset})), offset${checkByteLength ? ", length ?? (data ? data.byteLength - offset : " + byteOffset + "))" : ""}`);
 					else
 						start.push(`      super(data, offset, length ?? (data ? data.byteLength - offset : ${byteOffset}));`);
 
@@ -1151,7 +1160,7 @@ function compileDataView(input, pragmas = {}) {
 						classAlign = align;
 
 					if (flexibleArrayMember)
-						typescriptType = 'ArrayBuffer';
+						typescriptType = 'ArrayBufferLike';
 
 					if (doGet && !isPadding) {
 						output.push(jsdocComment);

--- a/compileDataView.js
+++ b/compileDataView.js
@@ -755,9 +755,9 @@ function compileDataView(input, pragmas = {}) {
 					});
 
 					if (!superClassName)
-						start.push(`      super(data ?? new ArrayBuffer(offset + (length ?? ${byteOffset})), offset${checkByteLength ? ", length ?? data?.byteLength ?? " + byteOffset : ""})`);
+						start.push(`      super(data ?? new ArrayBuffer(offset + (length ?? ${byteOffset})), offset${checkByteLength ? ", length ?? (data ? data.byteLength - offset : " + byteOffset + "))" : ""}`);
 					else
-						start.push(`      super(data, offset, length ?? data?.byteLength ?? ${byteOffset});`);
+						start.push(`      super(data, offset, length ?? (data ? data.byteLength - offset : ${byteOffset}));`);
 
 					if (classUsesEndian) {
 						start.push(`      this.setUint8(0, 1);`);

--- a/compileDataView.js
+++ b/compileDataView.js
@@ -1173,7 +1173,7 @@ function compileDataView(input, pragmas = {}) {
 							typescript: `   get ${name}(): ${(undefined === arrayCount) ? typescriptType ?? TypeScriptTypeAliases[type] : `${type}Array`} {`
 						});
 						if (flexibleArrayMember) 
-							output.push(`      return new Uint8Array(this.buffer.slice(${byteOffset}));`);
+							output.push(`      return new Uint8Array(this.buffer.slice(${byteOffset})).buffer;`);
 						else if (undefined === arrayCount) {
 							if (1 === byteCount)
 								output.push(`      return this.get${type}(${byteOffset});`);

--- a/compileDataView.js
+++ b/compileDataView.js
@@ -706,12 +706,12 @@ function compileDataView(input, pragmas = {}) {
 						for (let parentClass = superClassName; parentClass; parentClass = classes[parentClass]?.superClassName)
 							interfaceTypes += ` & I${parentClass}`;
 						output.add({
-							javascript: `   static from(obj, size) {`,
+							javascript: `   static from(obj, size = ${byteOffset}) {`,
 							typescript: `   static from(obj: ${strictFrom ? 'Required' : 'Partial'}<${interfaceTypes}>, size = ${byteOffset}): ${className} {`
 						});
 						if (superClassName)
 							output.add({
-								javascript: `      const result = super.from(obj, size);`,
+								javascript: `      const result = super.from(obj, size.${flexibleArrayMember}.byteLength);`,
 								typescript: `      const result = <${className}> super.from(obj, size${flexibleArrayMember ? " + (<" + className + "> obj)." + flexibleArrayMember + ".byteLength" : ""});`
 							});
 						else

--- a/compileDataView.js
+++ b/compileDataView.js
@@ -698,7 +698,7 @@ function compileDataView(input, pragmas = {}) {
 							interfaceTypes += ` & I${parentClass}`;
 						output.add({
 							javascript: `   static from(obj, size) {`,
-							typescript: `   static from(obj: ${strictFrom ? 'Required' : 'Partial'}<${interfaceTypes}>, size=${byteOffset}): ${className} {`
+							typescript: `   static from(obj: ${strictFrom ? 'Required' : 'Partial'}<${interfaceTypes}>, size = ${byteOffset}): ${className} {`
 						});
 						if (superClassName)
 							output.add({
@@ -750,14 +750,14 @@ function compileDataView(input, pragmas = {}) {
 
 				if (byteOffset > 0) {
 					start.add({
-						javascript: `   constructor(data, offset = 0, length = ${byteOffset}) {`,
-						typescript: `   constructor(data?: ArrayBufferLike, offset = 0, length = ${byteOffset}) {`
+						javascript: `   constructor(data, offset = 0, length) {`,
+						typescript: `   constructor(data?: ArrayBufferLike, offset = 0, length?: number) {`
 					});
 
 					if (!superClassName)
-						start.push(`      super(data ?? new ArrayBuffer(offset + length), offset${checkByteLength ? ", length" : ""})`);
+						start.push(`      super(data ?? new ArrayBuffer(offset + (length ?? ${byteOffset})), offset${checkByteLength ? ", length ?? data?.byteLength ?? " + byteOffset : ""})`);
 					else
-						start.push(`      super(data, offset, length);`);
+						start.push(`      super(data, offset, length ?? data?.byteLength ?? ${byteOffset});`);
 
 					if (classUsesEndian) {
 						start.push(`      this.setUint8(0, 1);`);

--- a/compileDataView.js
+++ b/compileDataView.js
@@ -1,21 +1,21 @@
 /*
-* Copyright (c) 2021-2022  Moddable Tech, Inc.
-*
-*   This file is part of the Moddable SDK Tools.
-*
-*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
-*   it under the terms of the GNU General Public License as published by
-*   the Free Software Foundation, either version 3 of the License, or
-*   (at your option) any later version.
-*
-*   The Moddable SDK Tools is distributed in the hope that it will be useful,
-*   but WITHOUT ANY WARRANTY; without even the implied warranty of
-*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*   GNU General Public License for more details.
-*
-*   You should have received a copy of the GNU General Public License
-*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (c) 2021-2022  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Tools.
+ *
+ *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Tools is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /*
 
@@ -40,7 +40,7 @@ const byteCounts = {
 	Float32: 4,
 	Float64: 8,
 	BigInt64: 8,
-	BigUint64: 8
+	BigUint64: 8,
 };
 
 const shiftCounts = {
@@ -53,40 +53,42 @@ const shiftCounts = {
 	Float32: 2,
 	Float64: 3,
 	BigInt64: 3,
-	BigUint64: 3
+	BigUint64: 3,
 };
 
 const TypeAliases = {
-	uint8_t:  "Uint8",
-	uint16_t:  "Uint16",
-	uint32_t:  "Uint32",
-	uint64_t:  "BigUint64",
-	int8_t:  "Int8",
-	int16_t:  "Int16",
-	int32_t:  "Int32",
-	int64_t:  "BigInt64",
-	float:  "Float32",
-	double:  "Float64",
-	boolean: "Boolean",
-	bool: "Boolean"
+	uint8_t: 'Uint8',
+	uint16_t: 'Uint16',
+	uint32_t: 'Uint32',
+	uint64_t: 'BigUint64',
+	int8_t: 'Int8',
+	int16_t: 'Int16',
+	int32_t: 'Int32',
+	int64_t: 'BigInt64',
+	float: 'Float32',
+	double: 'Float64',
+	boolean: 'Boolean',
+	bool: 'Boolean',
 };
 
 const TypeScriptTypeAliases = {
-	Uint8: "number",
-	Uint16: "number",
-	Uint32: "number",
-	BigUint64: "bigint",
-	Int8: "number",
-	Int16: "number",
-	Int32: "number",
-	BigInt64: "bigint",
-	Float32: "number",
-	Float64: "number",
-	Boolean: "boolean"
-}
+	Uint8: 'number',
+	Uint16: 'number',
+	Uint32: 'number',
+	BigUint64: 'bigint',
+	Int8: 'number',
+	Int16: 'number',
+	Int32: 'number',
+	BigInt64: 'bigint',
+	Float32: 'number',
+	Float64: 'number',
+	Boolean: 'boolean',
+};
 
-const isTypedef = Symbol("typedef");
-const anonymous = Symbol("anonymous");
+const EnumTypes = [];
+
+const isTypedef = Symbol('typedef');
+const anonymous = Symbol('anonymous');
 
 let className;
 let superClassName;
@@ -99,8 +101,8 @@ let jsonOutput;
 let fromOutput;
 let byteOffset;
 let littleEndian;
-let hostEndian
-let useEndian;	// = littleEndian ?? hostEndian
+let hostEndian;
+let useEndian; // = littleEndian ?? hostEndian
 let language;
 let platform;
 let doSet;
@@ -135,95 +137,88 @@ let outputSource;
 
 class Output extends Array {
 	add(line) {
-		if ("object" === typeof line) {
+		if ('object' === typeof line) {
 			line = line[language];
-			if (undefined === line)
-				throw new Error(`no generated code for ${language}`);
+			if (undefined === line) throw new Error(`no generated code for ${language}`);
 		}
 		if (line.length) this.push(line);
 	}
 	push(value, etc) {
-		if (etc) throw new Error("unexpected");
-		if (undefined === value)
-			return;
+		if (etc) throw new Error('unexpected');
+		if (undefined === value) return;
 		super.push(value);
 	}
 }
 
-const hex = "0123456789ABCDEF";
+const hex = '0123456789ABCDEF';
 function toHex(value, byteCount = 4) {
-	let result = "";
+	let result = '';
 	let nybbles = byteCount * 2;
 	while (value && nybbles--) {
 		result = hex[value & 15] + result;
-		value = (value & 0xFFFFFFF0) >>> 4;
+		value = (value & 0xfffffff0) >>> 4;
 	}
-	return "0x" + (("" === result) ? "0" : result);
+	return '0x' + ('' === result ? '0' : result);
 }
 
 function booleanSetting(value, name) {
-	if ("true" === value)
-		return true;
+	if ('true' === value) return true;
 
-	if ("false" === value)
-		return false;
+	if ('false' === value) return false;
 
 	throw new Error(`invalid ${name} "${value}" specified`);
 }
 
 function endField(byteCount) {
-	if (undefined !== union)
-		union = Math.max(byteCount, union);
-	else
-		byteOffset += byteCount;
+	if (undefined !== union) union = Math.max(byteCount, union);
+	else byteOffset += byteCount;
 }
 
 function validateName(name) {
 	//@@ naive
 	const c = name.charCodeAt(0);
-	if ((48 <= c) && (c < 58))
-		throw new Error(`invalid name "${name}"`);		
-	if (name.includes(";") || name.includes("+")  || name.includes("-") || name.includes(".") || name.includes("&"))
+	if (48 <= c && c < 58) throw new Error(`invalid name "${name}"`);
+	if (name.includes(';') || name.includes('+') || name.includes('-') || name.includes('.') || name.includes('&'))
 		throw new Error(`invalid name "${name}"`);
 
 	return name;
 }
 
 function splitSource(source) {
-	let parts = [], part = "";
+	let parts = [],
+		part = '';
 	let map = [];
 	let line = 1;
-	let directive = false, lineStart = true;
+	let directive = false,
+		lineStart = true;
 	let error;
 
-splitLoop:
-	for (let i = 0, length = source.length; i < length; i++) {
-		const c = source[i]
+	splitLoop: for (let i = 0, length = source.length; i < length; i++) {
+		const c = source[i];
 
-		if ("\n" === c)
-			lineStart = true;
+		if ('\n' === c) lineStart = true;
 
 		switch (c) {
-			case "*":
-				if ("/" === part) {
-					part = "";
+			case '*':
+				if ('/' === part) {
+					part = '';
 
-					const endComment = source.indexOf("*/", i);
+					const endComment = source.indexOf('*/', i);
 					if (endComment < 0) {
 						error = `unterminated comment, line ${line}`;
 						break splitLoop;
 					}
 					parts.push(source.slice(i - 1, endComment + 2));
 					map.push(line);
-					line += source.slice(i, endComment).split("\n").length - 1;
-					i = endComment + 1;		// with ++ in for loop, this gives next character
+					line += source.slice(i, endComment).split('\n').length - 1;
+					i = endComment + 1; // with ++ in for loop, this gives next character
 					continue splitLoop;
 				}
-				// fall through to handle "*" as separate part
+			// fall through to handle "*" as separate part
 
-			case "|":
-			case "&":
-			case "=":
+			case '|':
+			case '&':
+			case '=':
 				if (part) {
 					parts.push(part);
 					map.push(line);
@@ -231,43 +226,41 @@ splitLoop:
 				if (c === source[i + 1]) {
 					parts.push(c + c);
 					i += 1;
-				}
-				else
-					parts.push(c);
+				} else parts.push(c);
 				map.push(line);
-				part = "";
+				part = '';
 				break;
 
-			case "{":
-			case "}":
-			case ":":
-			case ";":
-			case "[":
-			case "]":
-			case "(":
-			case ")":
-			case "+":
-			case "-":
-			case "^":
-			case "!":
-			case ",":
+			case '{':
+			case '}':
+			case ':':
+			case ';':
+			case '[':
+			case ']':
+			case '(':
+			case ')':
+			case '+':
+			case '-':
+			case '^':
+			case '!':
+			case ',':
 				if (part) {
 					parts.push(part);
 					map.push(line);
 				}
 				parts.push(c);
 				map.push(line);
-				part = "";
+				part = '';
 				break;
 
-			case "\n":
-			case "\t":
-			case " ":
+			case '\n':
+			case '\t':
+			case ' ':
 				if (part) {
 					parts.push(part);
 					map.push(line);
 				}
-				if ("\n" === c) {
+				if ('\n' === c) {
 					if (directive) {
 						directive = false;
 						parts.push(c);
@@ -276,24 +269,22 @@ splitLoop:
 					line += 1;
 				}
 
-				part = "";
+				part = '';
 				break;
 
-			case "/":
-				if ("/" === part) {
-					part = "";
-					i = source.indexOf("\n", i);
-					if (i < 0)
-						break splitLoop;
-					i -= 1;		// so line ending is parsed
+			case '/':
+				if ('/' === part) {
+					part = '';
+					i = source.indexOf('\n', i);
+					if (i < 0) break splitLoop;
+					i -= 1; // so line ending is parsed
 					continue splitLoop;
 				}
 				part += c;
 				break;
 
-			case "#":
-				if (lineStart)
-					directive = true;
+			case '#':
+				if (lineStart) directive = true;
 				part += c;
 				break;
 
@@ -302,8 +293,7 @@ splitLoop:
 				break;
 		}
 
-		if ((" " !== c) && ("\t" !== c) && ("\n" !== c))
-			lineStart = false;
+		if (' ' !== c && '\t' !== c && '\n' !== c) lineStart = false;
 	}
 
 	if (part) {
@@ -311,49 +301,55 @@ splitLoop:
 		map.push(line);
 	}
 
-	return {parts, map, error};
+	return { parts, map, error };
 }
 
 function flushBitfields(bitsToAdd = 32) {
-	let total = 0, type, endian, byteCount;
+	let total = 0,
+		type,
+		endian,
+		byteCount;
 
-	for (let i = 0; i < bitfields.length; i++)
-		total += bitfields[i].bitCount;
+	for (let i = 0; i < bitfields.length; i++) total += bitfields[i].bitCount;
 
-	if ((0 == total) || ((total + bitsToAdd) <= 32))
-		return;
+	if (0 == total || total + bitsToAdd <= 32) return;
 
 	if (total <= 8) {
-		type = "Uint8";
+		type = 'Uint8';
 		byteCount = 1;
-		endian = "";
-	}
-	else {
-		type = (total <= 16) ? "Uint16" : "Uint32";
-		byteCount = (total <= 16) ? 2 : 4;
-		endian = useEndian ? ", true" : ", false";
+		endian = '';
+	} else {
+		type = total <= 16 ? 'Uint16' : 'Uint32';
+		byteCount = total <= 16 ? 2 : 4;
+		endian = useEndian ? ', true' : ', false';
 	}
 
 	let bitsOutput = 0;
 	while (bitfields.length) {
 		const bitfield = bitfields.shift();
-		const bitOffset = bitfieldsLSB ? bitsOutput : ((byteCount << 3) - bitsOutput - bitfield.bitCount);
-		const mask = (2 ** bitfield.bitCount) - 1;
-		const shiftLeft = bitOffset ? " << " + bitOffset : "";
-		const shiftRight = bitOffset ? " >> " + bitOffset : "";
+		const bitOffset = bitfieldsLSB ? bitsOutput : (byteCount << 3) - bitsOutput - bitfield.bitCount;
+		const mask = 2 ** bitfield.bitCount - 1;
+		const shiftLeft = bitOffset ? ' << ' + bitOffset : '';
+		const shiftRight = bitOffset ? ' >> ' + bitOffset : '';
 
 		if (doGet && !bitfield.name.startsWith(paddingPrefix)) {
-			if (bitfield.jsdocComment)
-				output.push(bitfield.jsdocComment);
+			if (bitfield.jsdocComment) output.push(bitfield.jsdocComment);
 
 			output.add({
 				javascript: `   get ${bitfield.name}() {`,
-				typescript: `   get ${bitfield.name}(): ${bitfield.boolean ? "boolean" : "number"} {`,
+				typescript: `   get ${bitfield.name}(): ${bitfield.boolean ? 'boolean' : 'number'} {`,
 			});
 			if (bitfield.boolean)
-				output.push(`      return Boolean(this.get${type}(${byteOffset}${endian}) & ${toHex(mask << bitOffset, byteCount)});`);
+				output.push(
+					`      return Boolean(this.get${type}(${byteOffset}${endian}) & ${toHex(
+						mask << bitOffset,
+						byteCount
+					)});`
+				);
 			else
-				output.push(`      return (this.get${type}(${byteOffset}${endian})${shiftRight}) & ${toHex(mask, byteCount)};`);
+				output.push(
+					`      return (this.get${type}(${byteOffset}${endian})${shiftRight}) & ${toHex(mask, byteCount)};`
+				);
 			output.push(`   }`);
 		}
 
@@ -362,19 +358,37 @@ function flushBitfields(bitsToAdd = 32) {
 
 			output.add({
 				javascript: `   set ${bitfield.name}(value) {`,
-				typescript: `   set ${bitfield.name}(value: ${bitfield.boolean ? "boolean" : "number"}) {`,
+				typescript: `   set ${bitfield.name}(value: ${bitfield.boolean ? 'boolean' : 'number'}) {`,
 			});
 			if (bitfield.boolean) {
 				output.push(`      const t = this.get${type}(${byteOffset}${endian});`);
-				output.push(`      this.set${type}(${byteOffset}, value ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(~(mask << bitOffset), byteCount)})${endian});`);
-			}
-			else if (1 === bitfield.bitCount) {
+				output.push(
+					`      this.set${type}(${byteOffset}, value ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(
+						~(mask << bitOffset),
+						byteCount
+					)})${endian});`
+				);
+			} else if (1 === bitfield.bitCount) {
 				output.push(`      const t = this.get${type}(${byteOffset}${endian});`);
-				output.push(`      this.set${type}(${byteOffset}, (value & 1) ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(~(mask << bitOffset), byteCount)})${endian});`);
-			}
-			else {
-				output.push(`      const t = this.get${type}(${byteOffset}${endian}) & ${toHex(~(mask << bitOffset), byteCount)};`);
-				output.push(`      this.set${type}(${byteOffset}, t | ((value & ${toHex(mask, byteCount)})${shiftLeft})${endian});`);
+				output.push(
+					`      this.set${type}(${byteOffset}, (value & 1) ? (t | ${toHex(1 << bitOffset)}) : (t & ${toHex(
+						~(mask << bitOffset),
+						byteCount
+					)})${endian});`
+				);
+			} else {
+				output.push(
+					`      const t = this.get${type}(${byteOffset}${endian}) & ${toHex(
+						~(mask << bitOffset),
+						byteCount
+					)};`
+				);
+				output.push(
+					`      this.set${type}(${byteOffset}, t | ((value & ${toHex(
+						mask,
+						byteCount
+					)})${shiftLeft})${endian});`
+				);
 			}
 			output.push(`   }`);
 		}
@@ -389,127 +403,110 @@ function flushBitfields(bitsToAdd = 32) {
 
 function setPragma(setting, value) {
 	switch (setting) {
-		case "extends":
-			extendsClass = value ? validateName(value) : "DataView"
+		case 'extends':
+			extendsClass = value ? validateName(value) : 'DataView';
 			break;
 
-		case "endian":
-			if ("little" === value)
-				littleEndian = true;
-			else if ("big" === value)
-				littleEndian = false;
-			else if ("host" === value)
-				littleEndian = undefined;
-			else
-				throw new Error(`invalid endian "${value}" specified`);
+		case 'endian':
+			if ('little' === value) littleEndian = true;
+			else if ('big' === value) littleEndian = false;
+			else if ('host' === value) littleEndian = undefined;
+			else throw new Error(`invalid endian "${value}" specified`);
 
 			useEndian = littleEndian ?? hostEndian;
 			break;
 
-		case "hostEndian":
-			if (output.length || final.length || className)
-				throw new Error("too late to set hostEndian");
+		case 'hostEndian':
+			if (output.length || final.length || className) throw new Error('too late to set hostEndian');
 
-			if ("little" === value)
-				hostEndian = true;
-			else if ("big" === value)
-				hostEndian = false;
-			else if ("unknown" === value)
-				hostEndian = undefined;
-			else
-				throw new Error(`invalid hostEndian "${value}" specified`);
+			if ('little' === value) hostEndian = true;
+			else if ('big' === value) hostEndian = false;
+			else if ('unknown' === value) hostEndian = undefined;
+			else throw new Error(`invalid hostEndian "${value}" specified`);
 
 			useEndian = littleEndian ?? hostEndian;
 			break;
 
-		case "pack":
-			if (")" === value) {
-				value =  kDefaultPack;
+		case 'pack':
+			if (')' === value) {
+				value = kDefaultPack;
 				pos -= 1;
-			}
-			else {
+			} else {
 				value = parseInt(value);
-				if (0 === value)
-					value = kDefaultPack;
-				if (![1, 2, 4, 8, 16].includes(value))
-					throw new Error(`invalid pack`);
+				if (0 === value) value = kDefaultPack;
+				if (![1, 2, 4, 8, 16].includes(value)) throw new Error(`invalid pack`);
 			}
 			pack = value;
 			break;
 
-		case "language":
-			if (output.length || final.length || className)
-				throw new Error("too late to set language");
+		case 'language':
+			if (output.length || final.length || className) throw new Error('too late to set language');
 
 			const languageParts = value.split('/');
 			if (languageParts.length < 1 || languageParts.length > 2)
 				throw new Error(`invalid language "${value}" specified; missing <language>{/<platform>}`);
 
-			if (!["javascript", "typescript"].includes(languageParts[0]))
+			if (!['javascript', 'typescript'].includes(languageParts[0]))
 				throw new Error(`invalid language "${value}" specified; language "${languageParts[0]}" unknown`);
-			if (2 == languageParts.length && !["xs", "node", "web"].includes(languageParts[1]))
+			if (2 == languageParts.length && !['xs', 'node', 'web'].includes(languageParts[1]))
 				throw new Error(`invalid language "${value}" specified; platform "${languageParts[1]}" unknown`);
 
 			language = languageParts[0];
-			platform = languageParts[1] ?? "xs";
+			platform = languageParts[1] ?? 'xs';
 			break;
 
-		case "set":
+		case 'set':
 			doSet = booleanSetting(value, setting);
 			break;
 
-		case "get":
+		case 'get':
 			doGet = booleanSetting(value, setting);
 			break;
 
-		case "export":
+		case 'export':
 			doExport = booleanSetting(value, setting);
 			break;
 
-		case "outputByteLength":
+		case 'outputByteLength':
 			outputByteLength = booleanSetting(value, setting);
 			break;
 
-		case "checkByteLength":
+		case 'checkByteLength':
 			checkByteLength = booleanSetting(value, setting);
 			break;
 
-		case "json":
+		case 'json':
 			json = booleanSetting(value, setting);
 			break;
 
-		case "bitfields":
-			if ("lsb" === value)
-				bitfieldsLSB = true;
-			else if ("msb" === value)
-				bitfieldsLSB = false;
-			else
-				throw new Error(`invalid bitfields "${value}" specified`);
+		case 'bitfields':
+			if ('lsb' === value) bitfieldsLSB = true;
+			else if ('msb' === value) bitfieldsLSB = false;
+			else throw new Error(`invalid bitfields "${value}" specified`);
 			break;
 
-		case "comments":
-			if (!["header", "false", "true"].includes(value))
-				throw new Error(`invalid comments "${value}" specified`);
+		case 'comments':
+			if (!['header', 'false', 'true'].includes(value)) throw new Error(`invalid comments "${value}" specified`);
 			comments = value;
 			break;
 
-		case "inject":
+		case 'inject':
 			if (jsdocClassComment) {
 				final.push(jsdocClassComment);
-				jsdocClassComment = "";
+				jsdocClassComment = '';
 			}
 			final.push(`${className ? '   ' : ''}${value};`);
 			break;
 
-		case "injectInterface":
+		case 'injectInterface':
 			injectInterface.push(`   ${value};`);
 			break;
 
-		case "import":
+		case 'import':
 			imports.push(`import ${value};`);
 			break;
 
-		case "outputSource":
+		case 'outputSource':
 			outputSource = booleanSetting(value, setting);
 			break;
 
@@ -525,82 +522,77 @@ function compileDataView(input, pragmas = {}) {
 	className = undefined;
 	superClassName = undefined;
 	classUsesEndian = false;
-	output = new Output;
+	output = new Output();
 	properties = [];
 	classes = {};
 	bitfields = [];
-	jsonOutput = new Output;
-	fromOutput = new Output;
+	jsonOutput = new Output();
+	fromOutput = new Output();
 	byteOffset = 0;
 	littleEndian = undefined;
 	hostEndian = true;
-	useEndian = littleEndian ?? hostEndian
-	language = "javascript";
-	platform = "xs";
+	useEndian = littleEndian ?? hostEndian;
+	language = 'javascript';
+	platform = 'xs';
 	doSet = true;
 	doGet = true;
 	doExport = true;
 	pack = kDefaultPack;
-	extendsClass = "DataView";
+	extendsClass = 'DataView';
 	imports = [];
 	outputByteLength = false;
 	checkByteLength = true;
 	union = undefined;
 	enumState = undefined;
-	enums = new Set;
-	enumContext = "";
+	enums = new Set();
+	enumContext = '';
 	classAlign = 0;
 	anonymousUnion = false;
 	json = false;
 	bitfieldsLSB = true;
-	comments = "header";
+	comments = 'header';
 	jsdocComment = undefined;
 	jsdocClassComment = undefined;
-	header = "";
+	header = '';
 	usesText = false;
 	usesEndianProxy = false;
 	usesViewArray = false;
-	conditionals = [{active: true, else: true}];
-	paddingPrefix = "__pad";
+	conditionals = [{ active: true, else: true }];
+	paddingPrefix = '__pad';
 	injectInterface = [];
 	exports = [];
 	outputSource = true;
 
 	final = [];
 	const errors = [];
-	const lines = input.split("\n");
+	const lines = input.split('\n');
 
-	const {parts, map, error} = splitSource(input);
+	const { parts, map, error } = splitSource(input);
 	if (error) {
 		errors.push(`   ${error}`);
 		parts.length = 0;
 	}
 
-	for (const name in pragmas)
-		setPragma(name, pragmas[name]);
+	for (const name in pragmas) setPragma(name, pragmas[name]);
 
 	for (let pos = 0; pos < parts.length; ) {
 		const part = parts[pos++];
-		if (!part)
-			throw new Error("unexpected state");
+		if (!part) throw new Error('unexpected state');
 
 		try {
 			let bitCount, arrayCount;
 
 			if (!conditionals[conditionals.length - 1].active) {
-				if (("#if" !== part) && ("#else" !== part) && ("#endif" !== part))
-					continue;
+				if ('#if' !== part && '#else' !== part && '#endif' !== part) continue;
 			}
 
-			if ("}" == part) {
-				if (!className)
-					throw new Error(`unexpected }`);
+			if ('}' == part) {
+				if (!className) throw new Error(`unexpected }`);
 
 				flushBitfields();
 
 				if (undefined !== union) {
-					if (0 === union)
-						throw new Error(`empty union`);
+					if (0 === union) throw new Error(`empty union`);
 
 					const byteLength = union;
 					union = undefined;
@@ -609,13 +601,11 @@ function compileDataView(input, pragmas = {}) {
 					if (anonymousUnion) {
 						anonymousUnion = false;
 
-						if (";" !== parts[pos++])
-							throw new Error(`expected semicolon`);
+						if (';' !== parts[pos++]) throw new Error(`expected semicolon`);
 
 						continue;
 					}
-				}
-				else if (undefined !== enumState) {
+				} else if (undefined !== enumState) {
 					if (anonymous !== className) {
 						exports.push(className);
 
@@ -625,8 +615,7 @@ function compileDataView(input, pragmas = {}) {
 						});
 						for (let [name, { value, jsdocComment }] of enumState) {
 							output.push(jsdocComment);
-							if ("string" === typeof value)
-								value = '"' + value + '"';
+							if ('string' === typeof value) value = '"' + value + '"';
 							output.add({
 								javascript: `   ${name}: ${value},`,
 								typescript: `   ${name} = ${value},`,
@@ -644,11 +633,12 @@ function compileDataView(input, pragmas = {}) {
 						const enumBackingBytes = byteCounts[enumBackingType];
 
 						classes[className] = {
-							byteLength:  enumBackingBytes,
+							byteLength: enumBackingBytes,
 							align: Math.min(pack, enumBackingBytes),
-							alignLength: enumBackingBytes 
+							alignLength: enumBackingBytes,
 						};
 						TypeAliases[className] = enumBackingType;
+						EnumTypes.push(className);
 					}
 
 					enumState = undefined;
@@ -659,23 +649,20 @@ function compileDataView(input, pragmas = {}) {
 
 				if (isTypedef === className) {
 					className = validateName(parts[pos++]);
-					if (classes[className])
-						throw new Error(`duplicate class "${className}"`);
+					if (classes[className]) throw new Error(`duplicate class "${className}"`);
 				}
 
-				if (";" !== parts[pos++])
-					throw new Error(`expected semicolon`);
+				if (';' !== parts[pos++]) throw new Error(`expected semicolon`);
 
 				if (json && byteOffset) {
 					if (doGet) {
 						output.add({
 							javascript: `   toJSON() {`,
-							typescript: `   toJSON(): object {`
+							typescript: `   toJSON(): object {`,
 						});
 						output.push(`      return {`);
 						output = output.concat(jsonOutput);
-						if (superClassName)
-							output.push(`         ...super.toJSON()`);
+						if (superClassName) output.push(`         ...super.toJSON()`);
 						output.push(`      };`);
 						output.push(`   }`);
 					}
@@ -683,20 +670,23 @@ function compileDataView(input, pragmas = {}) {
 
 					if (doSet) {
 						let interfaceTypes = `I${className}`;
-						for (let parentClass = superClassName; parentClass; parentClass = classes[parentClass]?.superClassName)
+						for (
+							let parentClass = superClassName;
+							parentClass;
+							parentClass = classes[parentClass]?.superClassName
+						)
 							interfaceTypes += ` & I${parentClass}`;
 						output.add({
 							javascript: `   static from(obj) {`,
-							typescript: `   static from(obj: ${interfaceTypes}): ${className} {`
+							typescript: `   static from(obj: ${interfaceTypes}): ${className} {`,
 						});
 						if (superClassName)
 							output.add({
 								javascript: `      const result = super.from(obj);`,
-								typescript: `      const result = <${className}> super.from(obj);`
+								typescript: `      const result = <${className}> super.from(obj);`,
 							});
-						else
-							output.push(`      const result = new this();`);
-						output = output.concat(fromOutput.map(e => e.replace("##LATE_CAST##", className)));
+						else output.push(`      const result = new this();`);
+						output = output.concat(fromOutput.map((e) => e.replace('##LATE_CAST##', className)));
 						output.push(`      return result;`);
 						output.push(`   }`);
 					}
@@ -706,9 +696,9 @@ function compileDataView(input, pragmas = {}) {
 				output.push(`}`);
 				output.push(``);
 
-				const start = new Output;
-				if ("typescript" == language) {
-					exports.push("I" + className);
+				const start = new Output();
+				if ('typescript' == language) {
+					exports.push('I' + className);
 					start.push(jsdocClassComment);
 					if (injectInterface.length == 0)
 						start.push(`type I${className} = Omit<${className}, keyof DataView | "toJSON">;`);
@@ -725,27 +715,31 @@ function compileDataView(input, pragmas = {}) {
 				jsdocClassComment = undefined;
 
 				let superByteLength = 0;
-				for (let parentClass = superClassName; classes[parentClass]; parentClass = classes[parentClass].extendsClass)  
+				for (
+					let parentClass = superClassName;
+					classes[parentClass];
+					parentClass = classes[parentClass].extendsClass
+				)
 					superByteLength += classes[parentClass].byteLength;
 
-				if (outputByteLength)
-					start.push(`   static byteLength = ${byteOffset}`);
-				if (classUsesEndian)
-					start.push(`   #endian;`);
+				if (outputByteLength) start.push(`   static byteLength = ${byteOffset}`);
+				if (classUsesEndian) start.push(`   #endian;`);
 
-				if (outputByteLength || classUsesEndian)
-					start.push(``);
+				if (outputByteLength || classUsesEndian) start.push(``);
 
 				if (byteOffset > 0) {
 					start.add({
 						javascript: `   constructor(data, offset = 0, length = ${byteOffset}) {`,
-						typescript: `   constructor(data?: ArrayBufferLike, offset = 0, length = ${byteOffset}) {`
+						typescript: `   constructor(data?: ArrayBufferLike, offset = 0, length = ${byteOffset}) {`,
 					});
 
 					if (!superClassName)
-						start.push(`      super(data ?? new ArrayBuffer(offset + length), offset${checkByteLength ? ", length" : ""})`);
-					else
-						start.push(`      super(data, offset, length);`);
+						start.push(
+							`      super(data ?? new ArrayBuffer(offset + length), offset${
+								checkByteLength ? ', length' : ''
+							})`
+						);
+					else start.push(`      super(data, offset, length);`);
 
 					if (classUsesEndian) {
 						start.push(`      this.setUint8(0, 1);`);
@@ -762,7 +756,7 @@ function compileDataView(input, pragmas = {}) {
 					align: classAlign,
 					alignLength: Math.ceil(byteOffset / classAlign) * classAlign,
 					superClassName,
-					superByteLength
+					superByteLength,
 				};
 
 				output.length = 0;
@@ -775,12 +769,10 @@ function compileDataView(input, pragmas = {}) {
 				continue;
 			}
 
-			if ((part === "union") && ("{" === parts[pos])) {
-				if (!className)
-					throw new Error(`anonymous union must be in struct`);
+			if (part === 'union' && '{' === parts[pos]) {
+				if (!className) throw new Error(`anonymous union must be in struct`);
 
-				if (undefined !== union)
-					throw new Error(`no nested unions`);
+				if (undefined !== union) throw new Error(`no nested unions`);
 
 				union = 0;
 				anonymousUnion = true;
@@ -789,13 +781,11 @@ function compileDataView(input, pragmas = {}) {
 				continue;
 			}
 
-			if (part === "union") {
-				if ("{" !== parts[pos + 1])
-					throw new Error(`open brace expected`);
+			if (part === 'union') {
+				if ('{' !== parts[pos + 1]) throw new Error(`open brace expected`);
 
 				className = validateName(parts[pos]);
-				if (classes[className])
-					throw new Error(`duplicate class "${className}"`);
+				if (classes[className]) throw new Error(`duplicate class "${className}"`);
 				classAlign = 1;
 
 				union = 0;
@@ -805,116 +795,98 @@ function compileDataView(input, pragmas = {}) {
 				continue;
 			}
 
-			if (part === "enum") {
-				if (className)
-					throw new Error(`enum must be at root`);
+			if (part === 'enum') {
+				if (className) throw new Error(`enum must be at root`);
 
 				let backingType = 'int32_t';
 
-				if ("{" !== parts[pos]) {
+				if ('{' !== parts[pos]) {
 					className = validateName(parts[pos++]);
-					if (classes[className])
-						throw new Error(`duplicate name "${enumState.name}"`);
+					if (classes[className]) throw new Error(`duplicate name "${enumState.name}"`);
 
 					if (':' == parts[pos]) {
 						backingType = parts[pos + 1];
-						if (!TypeAliases[backingType])
-							throw new Error(`unknown enum type ${backingType}`);
+						if (!TypeAliases[backingType]) throw new Error(`unknown enum type ${backingType}`);
 						pos += 2;
 					}
-				}
-				else
-					className = anonymous;
+				} else className = anonymous;
 
-				enumState = new Map;
+				enumState = new Map();
 				enumState.value = -1;
 				enumState.backingType = backingType;
+				enumState.typeName = className === anonymous ? backingType : className;
 
-				if ("{" !== parts[pos++])
-					throw new Error(`open brace expected`);
+				if ('{' !== parts[pos++]) throw new Error(`open brace expected`);
 
 				continue;
 			}
 
-			if (("typedef" === part) && (("struct" === parts[pos]) || (("volatile" == parts[pos]) && ("struct" === parts[pos + 1])))) {
-				if (className)
-					throw new Error(`cannot nest structure`);
+			if (
+				'typedef' === part &&
+				('struct' === parts[pos] || ('volatile' == parts[pos] && 'struct' === parts[pos + 1]))
+			) {
+				if (className) throw new Error(`cannot nest structure`);
 
-				if ("volatile" == parts[pos])
-					pos += 1;
+				if ('volatile' == parts[pos]) pos += 1;
 
-				if ("{" !== parts[pos + 1])
-					throw new Error(`open brace expected`);
+				if ('{' !== parts[pos + 1]) throw new Error(`open brace expected`);
 
 				className = isTypedef;
 				classAlign = 1;
-				jsonOutput = new Output;
-				fromOutput = new Output;
+				jsonOutput = new Output();
+				fromOutput = new Output();
 
 				pos += 2;
 				continue;
 			}
 
-			if ("struct" === part) {
-				if (className)
-					throw new Error(`cannot nest structure`);
+			if ('struct' === part) {
+				if (className) throw new Error(`cannot nest structure`);
 
 				className = validateName(parts[pos]);
-				if (classes[className])
-					throw new Error(`duplicate class "${className}"`);
+				if (classes[className]) throw new Error(`duplicate class "${className}"`);
 
-				if (":" == parts[pos + 1]) {
+				if (':' == parts[pos + 1]) {
 					superClassName = parts[pos + 2];
-					if (!classes[superClassName])
-						throw new Error(`unknown super class "${superClassName}"`)
+					if (!classes[superClassName]) throw new Error(`unknown super class "${superClassName}"`);
 					byteOffset = classes[superClassName].byteLength;
 				}
 
-				if ("{" !== parts[pos + (superClassName ? 3 : 1)])
-					throw new Error(`open brace expected`);
+				if ('{' !== parts[pos + (superClassName ? 3 : 1)]) throw new Error(`open brace expected`);
 
 				classAlign = 1;
-				jsonOutput = new Output;
-				fromOutput = new Output;
+				jsonOutput = new Output();
+				fromOutput = new Output();
 
-				pos += (superClassName ? 4 : 2);
+				pos += superClassName ? 4 : 2;
 				continue;
 			}
 
-			if (part.startsWith("/*")) {
-				if (("header" === comments) && (1 === pos))
-					header = part;
-				else if ("true" === comments) {
+			if (part.startsWith('/*')) {
+				if ('header' === comments && 1 === pos) header = part;
+				else if ('true' === comments) {
 					if (part.startsWith('/**')) {
-						if (className)
-							jsdocComment = '   ' + part;
-						else
-							jsdocClassComment = '\n' + part;
-					}
-					else {
-						if (className)
-							output.push('   ' + part);
-						else
-							final.push(part);
+						if (className) jsdocComment = '   ' + part;
+						else jsdocClassComment = '\n' + part;
+					} else {
+						if (className) output.push('   ' + part);
+						else final.push(part);
 					}
 				}
 				continue;
 			}
 
-			if ("#pragma" === part) {
+			if ('#pragma' === part) {
 				const setting = parts[pos++];
-				if ("(" !== parts[pos++])
-					throw new Error(`open parenthesis expected`);
+				if ('(' !== parts[pos++]) throw new Error(`open parenthesis expected`);
 
 				let value = [];
 				let nest = 0;
 				while (true) {
 					const part = parts[pos++];
-					if ("\n" === part)
-						throw new Error(`unbalanced parenthesis`);
-					if ("(" === part)
-						nest++;
-					else if (")" === part) {
+					if ('\n' === part) throw new Error(`unbalanced parenthesis`);
+					if ('(' === part) nest++;
+					else if (')' === part) {
 						if (0 === nest) {
 							pos--;
 							break;
@@ -923,26 +895,22 @@ function compileDataView(input, pragmas = {}) {
 					}
 					value.push(part);
 				}
-				value = value.join(" ");
-				
+				value = value.join(' ');
+
 				setPragma(setting, value);
 
-				if (")" !== parts[pos++])
-					throw new Error(`close parenthesis expected`);
+				if (')' !== parts[pos++]) throw new Error(`close parenthesis expected`);
 
-				if ("\n" !== parts[pos++])
-					throw new Error(`end of line expected`);
+				if ('\n' !== parts[pos++]) throw new Error(`end of line expected`);
 
 				continue;
 			}
-			if ("#if" === part) {
-				const end = parts.indexOf("\n", pos);
-				if (-1 == end)
-					throw new Error(`syntax error`);
-				if (!conditionals[conditionals.length - 1].active)
-					conditionals.push({active: false});
+			if ('#if' === part) {
+				const end = parts.indexOf('\n', pos);
+				if (-1 == end) throw new Error(`syntax error`);
+				if (!conditionals[conditionals.length - 1].active) conditionals.push({ active: false });
 				else {
-					const expression = parts.slice(pos, end).join(" ");
+					const expression = parts.slice(pos, end).join(' ');
 					let f = new Function(`
 						const p = new Proxy({}, {
 							has(target, property) {
@@ -965,269 +933,267 @@ function compileDataView(input, pragmas = {}) {
 						`);
 					const active = f() ?? false;
 					const type = typeof active;
-					if (("boolean" !== type) && ("number" !== type))
-						throw new Error(`invalid value for ${expression}`);
-					conditionals.push({active: !!active});
+					if ('boolean' !== type && 'number' !== type) throw new Error(`invalid value for ${expression}`);
+					conditionals.push({ active: !!active });
 				}
 
 				pos = end + 1;
 				continue;
 			}
-			if ("#else" === part) {
-				if ((conditionals.length < 2) || conditionals[conditionals.length - 1].else)
+			if ('#else' === part) {
+				if (conditionals.length < 2 || conditionals[conditionals.length - 1].else)
 					throw new Error(`unmatched #else`);
 				if (conditionals[conditionals.length - 2].active) {
 					conditionals[conditionals.length - 1].active = !conditionals[conditionals.length - 1].active;
 					conditionals[conditionals.length - 1].else = true;
 				}
 
-				const end = parts.indexOf("\n", pos);
-				if (-1 !== end)
-					pos = end + 1;
+				const end = parts.indexOf('\n', pos);
+				if (-1 !== end) pos = end + 1;
 				continue;
 			}
-			if ("#endif" === part) {
-				if (conditionals.length < 2)
-					throw new Error(`unmatched #endif`);
+			if ('#endif' === part) {
+				if (conditionals.length < 2) throw new Error(`unmatched #endif`);
 				conditionals.pop();
 
-				const end = parts.indexOf("\n", pos);
-				if (-1 !== end)
-					pos = end + 1;
+				const end = parts.indexOf('\n', pos);
+				if (-1 !== end) pos = end + 1;
 				continue;
 			}
-			if ("#error" === part) {
-				const end = parts.indexOf("\n", pos);
-				throw new Error(parts.slice(pos, (end < 0) ? parts.length : end).join(" "))
+			if ('#error' === part) {
+				const end = parts.indexOf('\n', pos);
+				throw new Error(parts.slice(pos, end < 0 ? parts.length : end).join(' '));
 			}
 
-			if (part.startsWith("#"))
-				throw new Error(`invalid preprocessor instruction`);
+			if (part.startsWith('#')) throw new Error(`invalid preprocessor instruction`);
 
-			if (";" === part)
-				continue;
+			if (';' === part) continue;
 
-			if (!className)
-				throw new Error(`unexpected`);
+			if (!className) throw new Error(`unexpected`);
 
 			if (enumState) {
-				if (enumState.has(part))
-					throw new Error(`duplicate name ${part} in enum`);
+				if (enumState.has(part)) throw new Error(`duplicate name ${part} in enum`);
 
 				let value = ++enumState.value;
-				if ("=" === parts[pos]) {
+				if ('=' === parts[pos]) {
 					pos += 1;
-					const comma = parts.indexOf(",", pos);
-					const brace = parts.indexOf("}", pos);
-					if ((-1 == comma) && (-1 == brace))
-						throw new Error(`syntax error`);
-					const end = Math.min((comma < 0) ? 32767 : comma, (brace < 0) ? 32767 : brace);
-					const expression = parts.slice(pos, end).join(" ");
-					let context = "(function () {\n" + enumContext;
+					const comma = parts.indexOf(',', pos);
+					const brace = parts.indexOf('}', pos);
+					if (-1 == comma && -1 == brace) throw new Error(`syntax error`);
+					const end = Math.min(comma < 0 ? 32767 : comma, brace < 0 ? 32767 : brace);
+					const expression = parts.slice(pos, end).join(' ');
+					let context = '(function () {\n' + enumContext;
 					context += `return ${expression};\n`;
-					context += `})();`
+					context += `})();`;
 					enumState.value = value = eval(context);
 					const type = typeof value;
-					if (("number" != type) && ("string" !== type) && ("boolean" !== type))
+					if ('number' != type && 'string' !== type && 'boolean' !== type)
 						throw new Error(`invalid value for ${part}`);
 					pos = end;
 				}
 
-				if ("," === parts[pos])
-					pos += 1;
-				else if ("}" === parts[pos])
-					;
-				else
-					throw new Error(`syntax error`);
+				if (',' === parts[pos]) pos += 1;
+				else if ('}' === parts[pos]);
+				else throw new Error(`syntax error`);
 
-				if (enums.has(part))
-					throw new Error(`duplicate enum: ${part}`);
+				if (enums.has(part)) throw new Error(`duplicate enum: ${part}`);
 				enums.add(part);
 
 				enumState.set(part, { value, jsdocComment });
 				jsdocComment = undefined;
 
-				if ("string" === typeof value)
-					value = '"' + value + '"';
+				if ('string' === typeof value) value = '"' + value + '"';
 				enumContext += `const ${part} = ${value};\n`;
 
 				continue;
 			}
 
-
 			let type = part;
 			let name = validateName(parts[pos++]);
 			const isPadding = name.startsWith(paddingPrefix);
 
-			if (":" === parts[pos]) {
+			if (':' === parts[pos]) {
 				pos++;
 				bitCount = parseInt(parts[pos++]);
-				if ((bitCount <= 0) || (bitCount > 32) || isNaN(bitCount))
-					throw new Error(`invalid bit count`);
-			}
-			else {
-				if ("[" == parts[pos]) {
-					const bracket = parts.indexOf("]", pos + 1);
-					if (bracket < 0)
-						throw new Error(`right brace expected`);
+				if (bitCount <= 0 || bitCount > 32 || isNaN(bitCount)) throw new Error(`invalid bit count`);
+			} else {
+				if ('[' == parts[pos]) {
+					const bracket = parts.indexOf(']', pos + 1);
+					if (bracket < 0) throw new Error(`right brace expected`);
 
-					const expression = parts.slice(pos + 1, bracket).join(" ");
-					let context = "(function () {\n" + enumContext;
+					const expression = parts.slice(pos + 1, bracket).join(' ');
+					let context = '(function () {\n' + enumContext;
 					context += `return ${expression};\n`;
-					context += `})();`
+					context += `})();`;
 
 					arrayCount = eval(context);
 					pos = bracket + 1;
 
 					arrayCount = Math.round(arrayCount);
-					if ((arrayCount <= 0) || isNaN(arrayCount) || (Infinity === arrayCount))
+					if (arrayCount <= 0 || isNaN(arrayCount) || Infinity === arrayCount)
 						throw new Error(`invalid array count`);
 				}
 			}
 
-			if (properties.includes(name))
-				throw new Error(`duplicate name "${name}"`);
+			if (properties.includes(name)) throw new Error(`duplicate name "${name}"`);
 			properties.push(name);
 
-			if (";" !== parts[pos++])
-				throw new Error(`expected semicolon`);
-
-			if (TypeAliases[type])
-				type = TypeAliases[type];
+			if (';' !== parts[pos++]) throw new Error(`expected semicolon`);
+			let typescriptType = EnumTypes[EnumTypes.indexOf(type)];
+			if (TypeAliases[type]) type = TypeAliases[type];
 
 			if (bitCount) {
-				if (("Uint8" === type) || ("Uint16" === type) || ("Uint32" === type)) {
+				if ('Uint8' === type || 'Uint16' === type || 'Uint32' === type) {
 					const byteCount = byteCounts[type];
-					if ((byteCount * 8) < bitCount)
-						throw new Error(`${type} too small for bitfield`);
-					type = "Uint";
+					if (byteCount * 8 < bitCount) throw new Error(`${type} too small for bitfield`);
+					type = 'Uint';
 				}
 			}
 
 			switch (type) {
-				case "Float32":
-				case "Float64":
-				case "Int8":
-				case "Int16":
-				case "Int32":
-				case "Uint8":
-				case "Uint16":
-				case "Uint32":
-				case "BigInt64":
-				case "BigUint64": {
-					flushBitfields();
-					if (undefined !== bitCount)
-						throw new Error(`cannot use bitfield with "${type}"`);
+				case 'Float32':
+				case 'Float64':
+				case 'Int8':
+				case 'Int16':
+				case 'Int32':
+				case 'Uint8':
+				case 'Uint16':
+				case 'Uint32':
+				case 'BigInt64':
+				case 'BigUint64':
+					{
+						flushBitfields();
+						if (undefined !== bitCount) throw new Error(`cannot use bitfield with "${type}"`);
 
-					const byteCount = byteCounts[type];
+						const byteCount = byteCounts[type];
 
-					const align = Math.min(pack, byteCount);
-					if (byteOffset % align)
-						endField(align - (byteOffset % align));
+						const align = Math.min(pack, byteCount);
+						if (byteOffset % align) endField(align - (byteOffset % align));
 
-					if (classAlign < align)
-						classAlign = align;
+						if (classAlign < align) classAlign = align;
 
-					if (doGet && !isPadding) {
-						output.push(jsdocComment);
-
-						output.add({
-							javascript: `   get ${name}() {`,
-							typescript: `   get ${name}(): ${(undefined === arrayCount) ? TypeScriptTypeAliases[type] : `${type}Array`} {`
-						});
-						if (undefined === arrayCount) {
-							if (1 === byteCount)
-								output.push(`      return this.get${type}(${byteOffset});`);
-							else {
-								if (undefined !== useEndian)
-									output.push(`      return this.get${type}(${byteOffset}, ${useEndian});`);
+						if (doGet && !isPadding) {
+							output.push(jsdocComment);
+							output.add({
+								javascript: `   get ${name}() {`,
+								typescript: `   get ${name}(): ${
+									undefined === arrayCount ? typescriptType ?? TypeScriptTypeAliases[type] : `${type}Array`
+								} {`,
+							});
+							if (undefined === arrayCount) {
+								if (1 === byteCount) output.push(`      return this.get${type}(${byteOffset});`);
 								else {
-									output.push(`      return this.get${type}(${byteOffset}, this.#endian);`);
-									classUsesEndian = true;
+									if (undefined !== useEndian)
+										output.push(`      return this.get${type}(${byteOffset}, ${useEndian});`);
+									else {
+										output.push(`      return this.get${type}(${byteOffset}, this.#endian);`);
+										classUsesEndian = true;
+									}
+								}
+							} else {
+								if (1 === byteCount || hostEndian === useEndian)
+									output.push(
+										`      return new ${type}Array(this.buffer, this.byteOffset${
+											byteOffset ? ' + ' + byteOffset : ''
+										}, ${arrayCount});`
+									);
+								else {
+									output.push(
+										`      return new EndianArray(${useEndian}, ${
+											shiftCounts[type]
+										}, DataView.prototype.get${type}, DataView.prototype.set${type}, this.buffer, this.byteOffset${
+											byteOffset ? ' + ' + byteOffset : ''
+										}, ${arrayCount});`
+									);
+									usesEndianProxy = true;
 								}
 							}
+							output.push(`   }`);
 						}
-						else {
-							if ((1 === byteCount) || (hostEndian === useEndian))
-								output.push(`      return new ${type}Array(this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount});`);
-							else {
-								output.push(`      return new EndianArray(${useEndian}, ${shiftCounts[type]}, DataView.prototype.get${type}, DataView.prototype.set${type}, this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount});`);
-								usesEndianProxy = true;
-							}
-						}
-						output.push(`   }`);
-					}
 
-					if (doSet && !isPadding) {
-						output.push(jsdocComment);
+						if (doSet && !isPadding) {
+							output.push(jsdocComment);
 
-						output.add({
-							javascript: `   set ${name}(value) {`,
-							typescript: `   set ${name}(value: ${(undefined === arrayCount) ? TypeScriptTypeAliases[type] : `ArrayLike<${TypeScriptTypeAliases[type]}>`}) {`,
-						});
-						output.push();
-						if (undefined === arrayCount) {
-							if (1 === byteCount)
-								output.push(`      this.set${type}(${byteOffset}, value);`);
-							else {
-								if (undefined !== useEndian)
-									output.push(`      this.set${type}(${byteOffset}, value, ${useEndian});`);
+							output.add({
+								javascript: `   set ${name}(value) {`,
+								typescript: `   set ${name}(value: ${
+									undefined === arrayCount
+										? typescriptType ?? TypeScriptTypeAliases[type]
+										: `ArrayLike<${TypeScriptTypeAliases[type]}>`
+								}) {`,
+							});
+							output.push();
+							if (undefined === arrayCount) {
+								if (1 === byteCount) output.push(`      this.set${type}(${byteOffset}, value);`);
 								else {
-									output.push(`      this.set${type}(${byteOffset}, value, this.#endian);`);
-									classUsesEndian = true;
+									if (undefined !== useEndian)
+										output.push(`      this.set${type}(${byteOffset}, value, ${useEndian});`);
+									else {
+										output.push(`      this.set${type}(${byteOffset}, value, this.#endian);`);
+										classUsesEndian = true;
+									}
 								}
+							} else {
+								if (byteCount == 1 || undefined !== useEndian) {
+									output.push(
+										`      for (let i = 0, j = this.byteOffset${
+											byteOffset ? ' + ' + byteOffset : ''
+										}; i < ${arrayCount}; i++, j += ${byteCount})`
+									);
+									if (1 === byteCount) output.push(`         this.set${type}(j, value[i]);`);
+									else output.push(`         this.set${type}(j, value[i], ${useEndian});`);
+								} else
+									output.push(
+										`      (new ${type}Array(this.buffer, this.byteOffset${
+											byteOffset ? ' + ' + byteOffset : ''
+										}, ${arrayCount})).set(value);`
+									);
 							}
-						}
-						else {
-							if ((byteCount == 1) || (undefined !== useEndian)) {
-								output.push(`      for (let i = 0, j = this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}; i < ${arrayCount}; i++, j += ${byteCount})`);
-								if (1 === byteCount)
-									output.push(`         this.set${type}(j, value[i]);`);
-								else
-									output.push(`         this.set${type}(j, value[i], ${useEndian});`);
-							}
-							else
-								output.push(`      (new ${type}Array(this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount})).set(value);`);
+
+							output.push(`   }`);
 						}
 
-						output.push(`   }`);
+						endField((arrayCount ?? 1) * byteCount);
+
+						if (!isPadding) {
+							if (undefined === arrayCount) jsonOutput.push(`         ${name}: this.${name},`);
+							else jsonOutput.push(`         ${name}: Array.from(this.${name}),`);
+
+							fromOutput.add({
+								javascript: `      if ("${name}" in obj) result.${name} = obj.${name};`,
+								typescript: `      if ("${name}" in obj) result.${name} = (<##LATE_CAST##> obj).${name};`,
+							});
+						}
 					}
+					break;
 
-					endField((arrayCount ?? 1) * byteCount);
-
-					if (!isPadding) {
-						if (undefined === arrayCount)
-							jsonOutput.push(`         ${name}: this.${name},`);
-						else
-							jsonOutput.push(`         ${name}: Array.from(this.${name}),`);
-
-						fromOutput.add({
-							javascript: `      if ("${name}" in obj) result.${name} = obj.${name};`,
-							typescript: `      if ("${name}" in obj) result.${name} = (<##LATE_CAST##> obj).${name};`
-						});
-					}
-					} break;
-
-				case "char":
+				case 'char':
 					flushBitfields();
 
-					if (undefined !== bitCount)
-						throw new Error(`char cannot use bitfield`);
+					if (undefined !== bitCount) throw new Error(`char cannot use bitfield`);
 
 					if (doGet && !isPadding) {
-+						output.push(jsdocComment);
+						+output.push(jsdocComment);
 
 						output.add({
 							javascript: `   get ${name}() {`,
 							typescript: `   get ${name}(): string {`,
 						});
-						if ((undefined === arrayCount) || (1 === arrayCount))
+						if (undefined === arrayCount || 1 === arrayCount)
 							output.push(`      return String.fromCharCode(this.getUint8(${byteOffset}));`);
 						else {
-							if ("xs" === platform)
-								output.push(`      return String.fromArrayBuffer(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${byteOffset + arrayCount}));`);
+							if ('xs' === platform)
+								output.push(
+									`      return String.fromArrayBuffer(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${
+										byteOffset + arrayCount
+									}));`
+								);
 							else
-								output.push(`      return new TextDecoder().decode(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${byteOffset + arrayCount}));`);
+								output.push(
+									`      return new TextDecoder().decode(this.buffer.slice(this.byteOffset + ${byteOffset}, this.byteOffset + ${
+										byteOffset + arrayCount
+									}));`
+								);
 						}
 						output.push(`   }`);
 					}
@@ -1240,13 +1206,12 @@ function compileDataView(input, pragmas = {}) {
 							typescript: `   set ${name}(value: string) {`,
 						});
 						output.push();
-						if ((undefined === arrayCount) || (1 === arrayCount))
+						if (undefined === arrayCount || 1 === arrayCount)
 							output.push(`      this.setUint8(${byteOffset}, value.charCodeAt(0));`);
 						else {
-							if ("xs" === platform)
+							if ('xs' === platform)
 								output.push(`      const j = new Uint8Array(ArrayBuffer.fromString(value));`);
-							else
-								output.push(`      const j = new TextEncoder().encode(value);`);
+							else output.push(`      const j = new TextEncoder().encode(value);`);
 							output.push(`      const byteLength = j.byteLength;`);
 							output.push(`      if (byteLength > ${arrayCount})`);
 							output.push(`         throw new Error("too long");`);
@@ -1268,20 +1233,19 @@ function compileDataView(input, pragmas = {}) {
 							typescript: `      if ("${name}" in obj) result.${name} = (<##LATE_CAST##> obj).${name};`,
 						});
 					}
-					
+
 					usesText = true;
 					break;
 
-				case "Uint":
-					if (undefined === bitCount)
-						throw new Error(`number of bits in bitfield missing`);
+				case 'Uint':
+					if (undefined === bitCount) throw new Error(`number of bits in bitfield missing`);
 
 					flushBitfields(bitCount);
 
 					bitfields.push({
 						name,
 						bitCount,
-						jsdocComment
+						jsdocComment,
 					});
 
 					if (!isPadding) {
@@ -1294,20 +1258,18 @@ function compileDataView(input, pragmas = {}) {
 					}
 					break;
 
-				case "Boolean":
+				case 'Boolean':
 					flushBitfields(1);
 
-					if (undefined !== arrayCount)
-						throw new Error(`Boolean cannot have array`);
+					if (undefined !== arrayCount) throw new Error(`Boolean cannot have array`);
 
-					if (undefined !== bitCount)
-						throw new Error(`cannot use bitfield with "${type}"`);
+					if (undefined !== bitCount) throw new Error(`cannot use bitfield with "${type}"`);
 
 					bitfields.push({
 						name,
 						bitCount: 1,
 						boolean: true,
-						jsdocComment
+						jsdocComment,
 					});
 
 					if (!isPadding) {
@@ -1320,163 +1282,160 @@ function compileDataView(input, pragmas = {}) {
 					}
 					break;
 
-				default: {
-					if (!classes[type])
-						throw new Error(`unknown type "${type}"`);
+				default:
+					{
+						if (!classes[type]) throw new Error(`unknown type "${type}"`);
 
-					flushBitfields();
+						flushBitfields();
 
-					if (undefined !== bitCount)
-						throw new Error(`cannot use bitfield with "${type}"`);
+						if (undefined !== bitCount) throw new Error(`cannot use bitfield with "${type}"`);
 
-					const align = Math.min(pack, classes[type].align);
-					if (byteOffset % align)
-						endField(align - (byteOffset % align));
+						const align = Math.min(pack, classes[type].align);
+						if (byteOffset % align) endField(align - (byteOffset % align));
 
-					if (doGet && !isPadding) {
-						output.push(jsdocComment);
+						if (doGet && !isPadding) {
+							output.push(jsdocComment);
 
-						if (undefined === arrayCount) {
-							output.add({
-								javascript: `   get ${name}() {`,
-								typescript: `   get ${name}(): ${type} {`,
-							});
-								
-							output.push(`      return new ${type}(this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""});`);
-							output.push(`   }`);
+							if (undefined === arrayCount) {
+								output.add({
+									javascript: `   get ${name}() {`,
+									typescript: `   get ${name}(): ${type} {`,
+								});
+
+								output.push(
+									`      return new ${type}(this.buffer, this.byteOffset${
+										byteOffset ? ' + ' + byteOffset : ''
+									});`
+								);
+								output.push(`   }`);
+							} else {
+								output.add({
+									javascript: `   get ${name}() {`,
+									typescript: `   get ${name}(): ArrayLike<${type}> {`,
+								});
+
+								output.push(
+									`      return new ViewArray(${type}, this.buffer, this.byteOffset${
+										byteOffset ? ' + ' + byteOffset : ''
+									}, ${arrayCount}, ${classes[type].alignLength});`
+								);
+								output.push(`   }`);
+
+								usesViewArray = true;
+							}
 						}
-						else {
-							output.add({
-								javascript: `   get ${name}() {`,
-								typescript: `   get ${name}(): ArrayLike<${type}> {`,
+
+						if (doSet && !isPadding) {
+							output.push(jsdocComment);
+
+							if (undefined === arrayCount) {
+								output.add({
+									javascript: `   set ${name}(value) {`,
+									typescript: `   set ${name}(value: ${type}) {`,
+								});
+								output.push(`      for (let i = 0; i < ${classes[type].byteLength}; i++)`);
+								output.push(`         this.setUint8(i + ${byteOffset}, value.getUint8(i));`);
+								output.push(`   }`);
+							} else {
+								output.add({
+									javascript: `   set ${name}(value) {`,
+									typescript: `   set ${name}(value: ArrayLike<${type}>) {`,
+								});
+								output.push(
+									`      for (let i = 0, offset = 0; i < ${arrayCount}; i++, offset += ${classes[type].alignLength}) {`
+								);
+								output.push(
+									`         for (let j = 0, v = value[i]; j < ${classes[type].byteLength}; j++) {`
+								);
+								output.push(`            this.setUint8(j + offset + ${byteOffset}, v.getUint8(j));`);
+								output.push(`         }`);
+								output.push(`      }`);
+								output.push(`   }`);
+							}
+						}
+
+						if (undefined === arrayCount) endField(classes[type].byteLength);
+						else endField(arrayCount * classes[type].alignLength);
+
+						if (!isPadding) {
+							jsonOutput.push(`         ${name}: this.${name}.toJSON(),`);
+
+							fromOutput.add({
+								javascript: `      if ("${name}" in obj) result.${name} = ${type}.from(obj.${name});`,
+								typescript: `      if ("${name}" in obj) result.${name} = ${type}.from((<##LATE_CAST##> obj).${name});`,
 							});
-
-							output.push(`      return new ViewArray(${type}, this.buffer, this.byteOffset${byteOffset ? (" + " + byteOffset) : ""}, ${arrayCount}, ${classes[type].alignLength});`);
-							output.push(`   }`);
-
-							usesViewArray = true;
 						}
 					}
-
-					if (doSet && !isPadding) {
-						output.push(jsdocComment);
-
-						if (undefined === arrayCount) {
-							output.add({
-								javascript: `   set ${name}(value) {`,
-								typescript: `   set ${name}(value: ${type}) {`,
-							});
-							output.push(`      for (let i = 0; i < ${classes[type].byteLength}; i++)`);
-							output.push(`         this.setUint8(i + ${byteOffset}, value.getUint8(i));`);
-							output.push(`   }`);
-						}
-						else {
-							output.add({
-								javascript: `   set ${name}(value) {`,
-								typescript: `   set ${name}(value: ArrayLike<${type}>) {`,
-							});
-							output.push(`      for (let i = 0, offset = 0; i < ${arrayCount}; i++, offset += ${classes[type].alignLength}) {`) ;
-							output.push(`         for (let j = 0, v = value[i]; j < ${classes[type].byteLength}; j++) {`);
-							output.push(`            this.setUint8(j + offset + ${byteOffset}, v.getUint8(j));`);
-							output.push(`         }`);
-							output.push(`      }`);
-							output.push(`   }`);
-						}
-					}
-
-					if (undefined === arrayCount)
-						endField(classes[type].byteLength);
-					else
-						endField(arrayCount * classes[type].alignLength);
-
-
-					if (!isPadding) {
-						jsonOutput.push(`         ${name}: this.${name}.toJSON(),`);
-
-						fromOutput.add({
-							javascript: `      if ("${name}" in obj) result.${name} = ${type}.from(obj.${name});`,
-							typescript: `      if ("${name}" in obj) result.${name} = ${type}.from((<##LATE_CAST##> obj).${name});`,
-						});
-					}
-					} break;
+					break;
 			}
 			jsdocComment = undefined;
-
-		}
-		catch (e) {
+		} catch (e) {
 			errors.push(`   ${e}, line ${map[pos]}: ${lines[map[pos] - 1]}`);
 		}
 	}
 
-	if (conditionals.length > 1)
-		errors.push(`   missing #endif`);
+	if (conditionals.length > 1) errors.push(`   missing #endif`);
 
-	if (className)
-		errors.push(`   incomplete struct at end of file`);
+	if (className) errors.push(`   incomplete struct at end of file`);
 
-	if (usesText && ("node" === platform))
-		imports.push('import {TextEncoder, TextDecoder} from "util";');
+	if (usesText && 'node' === platform) imports.push('import {TextEncoder, TextDecoder} from "util";');
 
-	if (imports.length)
-		final.unshift(...imports, "");
+	if (imports.length) final.unshift(...imports, '');
 
-	if (header)
-		final.unshift(header, "");
+	if (header) final.unshift(header, '');
 
-	if (usesEndianProxy)
-		final.push(EndianProxy);
+	if (usesEndianProxy) final.push(EndianProxy);
 
-	if (usesViewArray)
-		final.push(ViewArray);
+	if (usesViewArray) final.push(ViewArray);
 
 	if (exports.length && doExport) {
-		final.push("");
-		let exportLine = "export { ";
+		final.push('');
+		let exportLine = 'export { ';
 		if (exports.length > 3) {
 			final.push(exportLine);
-			exportLine = "";
+			exportLine = '';
 		}
 		for (let i = 0; i < exports.length; ++i) {
 			if (exportLine.length > 80) {
-				final.push("   " + exportLine);
-				exportLine = "";
+				final.push('   ' + exportLine);
+				exportLine = '';
 			}
-			exportLine = exportLine + exports[i] + ((i < (exports.length - 1)) ? ', ' : '');
+			exportLine = exportLine + exports[i] + (i < exports.length - 1 ? ', ' : '');
 		}
-		if (exportLine != "") {
-			if (exports.length <= 3)
-				final.push(exportLine + " };");
+		if (exportLine != '') {
+			if (exports.length <= 3) final.push(exportLine + ' };');
 			else {
-				final.push("   " + exportLine);
-				final.push("};");
+				final.push('   ' + exportLine);
+				final.push('};');
 			}
 		}
 	}
 
 	if (outputSource) {
-		final.push("");
-		final.push("/*");
-		final.push(`\tView classes generated by https://phoddie.github.io/compileDataView on ${new Date} from the following description:`);
-		final.push("*/");
+		final.push('');
+		final.push('/*');
+		final.push(
+			`\tView classes generated by https://phoddie.github.io/compileDataView on ${new Date()} from the following description:`
+		);
+		final.push('*/');
 		final.push(input.replace(/^|\n/g, '\n// '));
 	}
 
 	if (errors.length) {
-		errors.unshift("/*")
-		errors.push("*/")
-		errors.push("")
+		errors.unshift('/*');
+		errors.push('*/');
+		errors.push('');
 	}
 
 	return {
-		script: final.join("\n"),
-		errors: errors.join("\n"),
-		language: ("typescript" === language) ? 'ts' : 'js',
-		platform
-	}
+		script: final.join('\n'),
+		errors: errors.join('\n'),
+		language: 'typescript' === language ? 'ts' : 'js',
+		platform,
+	};
 }
 
-const EndianProxy =
-`const Properties = Object.freeze({
+const EndianProxy = `const Properties = Object.freeze({
 	concat: Array.prototype.concat,
 	copyWithin: Array.prototype.copyWithin,
 	every: Array.prototype.every,
@@ -1558,8 +1517,7 @@ class EndianArray {
 }
 `;
 
-const ViewArray =
-`class ViewArray {
+const ViewArray = `class ViewArray {
 	constructor(View, buffer, byteOffset, count, size) {
 		if ((count * size) > (buffer.byteLength - byteOffset))
 			throw new RangeError;

--- a/example.cdv.h
+++ b/example.cdv.h
@@ -206,12 +206,12 @@ struct TypeThree : TypeOne {
    #pragma inject(type BaseTypes = ITypeOne | ITypeTwo | ITypeThree)
 #endif
 
-/* Example of using variable size data (ArrayBuffer) at end of a struct */
+/* Example of using flexible array members at end of a struct */
 struct Variable {
    uint16_t one;
    uint32_t two;
    char three;
-   char *data;
+   uint8_t data[];
 };
 
 struct SuperVariable {
@@ -220,6 +220,6 @@ struct SuperVariable {
 
 struct SubVariable : SuperVariable {
    uint32_t more;
-   char *data;
+   uint8_t data[];
 };
 

--- a/example.cdv.h
+++ b/example.cdv.h
@@ -206,3 +206,20 @@ struct TypeThree : TypeOne {
    #pragma inject(type BaseTypes = ITypeOne | ITypeTwo | ITypeThree)
 #endif
 
+/* Example of using variable size data (ArrayBuffer) at end of a struct */
+struct Variable {
+   uint16_t one;
+   uint32_t two;
+   char three;
+   char *data;
+};
+
+struct SuperVariable {
+   uint16_t myNumber;
+};
+
+struct SubVariable : SuperVariable {
+   uint32_t more;
+   char *data;
+};
+

--- a/example.cdv.h
+++ b/example.cdv.h
@@ -6,6 +6,7 @@
    #pragma json(true)                  // include JSON methods
    #pragma language(typescript/node)   // use TypeScript with Node style string buffers
    #pragma outputByteLength(true)      // include length of structures in output
+   #pragma strictFrom(true)            // require all properties on 'from` methods
 #endif
 
 // Line comments are always ignored

--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ let i = IntroView.from({
 });
 ```
 
-To use the `from` feature, set `#pragma json(true)` when compiling the view.
+To use the `from` feature, set `#pragma json(true)` when compiling the view.  When generating TypeScript, you can optionally use [`#pragma strictFrom(true)`](#strictFrom) to require all fields (versus the default of all fields are optional).
 
 <a id="stringify"></a>
 #### Serializing a binary data structure to JSON
@@ -557,6 +557,7 @@ The following pragmas are available (first option is the default):
 - [`outputByteLength(false | true)`](#outputbytelength)
 - [`outputSource(true | false)`](#outputsource)
 - [`pack(16 | 8 | 4 | 2 | 1)`](#pack)
+- ['strictFrom(false | true)`](#strictFrom)
 
 #### `extends`
 The `extends` pragma defines the name of the class the generated class extends. The default value is `DataView` and it is rarely necessary to use another value. For example, the following pragma
@@ -766,6 +767,11 @@ import { myMethod } from "./MyClass";
 ```
 
 Import pragmas may be placed anywhere in the content, but are always be injected at the top of the file (after the first comment if provided).
+
+<a id="strictFrom"></a>
+#### `strictFrom`
+
+When generating TypeScript and using the pragma `json` to generate the `from` method (see [initialize](#initialize)), this option will change the types to require all properties (using the utility type `Required`).  The default (`false`) is to allow a subset of properties to be provided (using the utility type `Partial`).  
 
 <!--
 #### `inject` and `injectInterface`

--- a/readme.md
+++ b/readme.md
@@ -575,7 +575,8 @@ The following pragmas are available (first option is the default):
 - [`outputByteLength(false | true)`](#outputbytelength)
 - [`outputSource(true | false)`](#outputsource)
 - [`pack(16 | 8 | 4 | 2 | 1)`](#pack)
-- ['strictFrom(false | true)`](#strictFrom)
+- [`strictFrom(false | true)`](#strictFrom)
+- [`useSharedArrayBuffer(false | true)`](#useSharedArrayBuffer)
 
 #### `extends`
 The `extends` pragma defines the name of the class the generated class extends. The default value is `DataView` and it is rarely necessary to use another value. For example, the following pragma
@@ -790,6 +791,11 @@ Import pragmas may be placed anywhere in the content, but are always be injected
 #### `strictFrom`
 
 When generating TypeScript and using the pragma `json` to generate the `from` method (see [initialize](#initialize)), this option will change the types to require all properties (using the utility type `Required`).  The default (`false`) is to allow a subset of properties to be provided (using the utility type `Partial`).  
+
+<a id="useSharedArrayBuffer"></a>
+#### `useSharedArrayBuffer`
+
+By default, `ArrayBuffer` is used for all buffer allocations.  Setting `useSharedArrayBuffer` to `true` will instead use a `SharedArrayBuffer` for allocations.  This is useful for sharing memory across workers as well as to use  the system heap for memory allocations (a separate memory domain on Moddable) instead of chunks.  This pragma may be turned on/off throughout the file to switch the allocation type used on a per-element basis.
 
 <!--
 #### `inject` and `injectInterface`

--- a/readme.md
+++ b/readme.md
@@ -415,6 +415,24 @@ i.str = "12"; // ok
 i.str = "123456789"; // throws
 ```
 
+<a id="pointers"></a>
+#### Variable length data at the end of the struct
+
+Some data structures, common with networking protocols, consist of a header followed by an arbitrary length collection of bytes.  This can be implemented in a `struct` using the `char *` notation.  You can have only one of these per `struct`, and it must be the last member defined.  It also may not be [inherited](#inheritance) (it must be the final subclass). 
+
+```js
+struct MyStruct : SuperStruct {
+   uint32_t someData;
+   char *data;
+}
+```
+
+To instantiate a new object that has the correct length buffer, use the static [`from`](#json) method which will determine the size of the provided `ArrayBuffer` to allocate the correct buffer size.
+
+```js
+MyStruct.from({ someData: 32, data: myArrayBuffer });
+```
+
 <a id="type-nested"></a>
 #### Nested types
 View declared in a description can be nested in views that follow it by using the class name as the type.

--- a/readme.md
+++ b/readme.md
@@ -415,15 +415,15 @@ i.str = "12"; // ok
 i.str = "123456789"; // throws
 ```
 
-<a id="pointers"></a>
-#### Variable length data at the end of the struct
+<a id="flexible-array-members"></a>
+#### Flexible array members
 
-Some data structures, common with networking protocols, consist of a header followed by an arbitrary length collection of bytes.  This can be implemented in a `struct` using the `char *` notation.  You can have only one of these per `struct`, and it must be the last member defined.  It also may not be [inherited](#inheritance) (it must be the final subclass). 
+Some data structures, common with networking protocols, consist of a header followed by an arbitrary length collection of bytes.  This can be implemented in a `struct` using the `uint8_t var[]` notation (empty array).  You can have only one of these per `struct`, and it must be the last member defined.  It also may not be [inherited](#inheritance) (it must be the final subclass). 
 
 ```js
 struct MyStruct : SuperStruct {
    uint32_t someData;
-   char *data;
+   uint8_t data[];
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -576,7 +576,7 @@ The following pragmas are available (first option is the default):
 - [`outputSource(true | false)`](#outputsource)
 - [`pack(16 | 8 | 4 | 2 | 1)`](#pack)
 - [`strictFrom(false | true)`](#strictFrom)
-- [`useSharedArrayBuffer(false | true)`](#useSharedArrayBuffer)
+- [`bufferAllocator(ArrayBuffer | <any allocator>)`](#bufferAllocator)
 
 #### `extends`
 The `extends` pragma defines the name of the class the generated class extends. The default value is `DataView` and it is rarely necessary to use another value. For example, the following pragma
@@ -792,10 +792,10 @@ Import pragmas may be placed anywhere in the content, but are always be injected
 
 When generating TypeScript and using the pragma `json` to generate the `from` method (see [initialize](#initialize)), this option will change the types to require all properties (using the utility type `Required`).  The default (`false`) is to allow a subset of properties to be provided (using the utility type `Partial`).  
 
-<a id="useSharedArrayBuffer"></a>
-#### `useSharedArrayBuffer`
+<a id="bufferAllocator"></a>
+#### `bufferAllocator`
 
-By default, `ArrayBuffer` is used for all buffer allocations.  Setting `useSharedArrayBuffer` to `true` will instead use a `SharedArrayBuffer` for allocations.  This is useful for sharing memory across workers as well as to use  the system heap for memory allocations (a separate memory domain on Moddable) instead of chunks.  This pragma may be turned on/off throughout the file to switch the allocation type used on a per-element basis.
+By default, `ArrayBuffer` is used for all buffer allocations.  Setting `bufferAllocator` to a buffer constructor will use a user defined allocator.  This is useful with `SharedArrayBuffer` for sharing memory across workers as well as to use  the system heap for memory allocations (a separate memory domain on Moddable) instead of chunks.  This pragma may be turned on/off throughout the file to switch the allocation type used on a per-element basis.
 
 <!--
 #### `inject` and `injectInterface`


### PR DESCRIPTION
Contains the following (for TypeScript, none of the changes should affect JavaScript generation):

1) Enum types on getters/setters were incorrectly being converted to `myEnum: number` when they should retain the original enum name (`myEnum: MyEnumName`).

2) TypeScript was enforcing all properties in the JSON `from` method to be supplied, when the intent of the method was to allow for optional properties.  This was corrected using the `Partial<...>` utility type.

3) Added a new pragma `strictFrom` which switches all `from` calls to requiring all types (by using the `Required<...>` utility type).  This is useful to ensure that any change made to the CDV source file is type-enforced on all `from` calls, so you get compile-time errors should you forget to update the calls.  It is defaulted off, (partial properties allowed), but can be enabled with `#pragma strictFrom(true)`.